### PR TITLE
Improve readability of tab screens in dark mode

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,42 +1,45 @@
 import React from "react";
 import { Tabs } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 
 export default function RootLayout() {
   return (
-    <Tabs
-      screenOptions={{
-        headerShown: true,
-        tabBarActiveTintColor: "#007AFF",
-      }}
-    >
-      <Tabs.Screen
-        name="index"
-        options={{
-          title: "Home",
-          tabBarIcon: ({ color, size }: { color: string; size: number }) => (
-            <Ionicons name="home" size={size} color={color} />
-          ),
+    <SafeAreaProvider>
+      <Tabs
+        screenOptions={{
+          headerShown: true,
+          tabBarActiveTintColor: "#007AFF",
         }}
-      />
-      <Tabs.Screen
-        name="customers"
-        options={{
-          title: "Customers",
-          tabBarIcon: ({ color, size }: { color: string; size: number }) => (
-            <Ionicons name="people" size={size} color={color} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="estimates"
-        options={{
-          title: "Estimates",
-          tabBarIcon: ({ color, size }: { color: string; size: number }) => (
-            <Ionicons name="document-text" size={size} color={color} />
-          ),
-        }}
-      />
-    </Tabs>
+      >
+        <Tabs.Screen
+          name="index"
+          options={{
+            title: "Home",
+            tabBarIcon: ({ color, size }: { color: string; size: number }) => (
+              <Ionicons name="home" size={size} color={color} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="customers"
+          options={{
+            title: "Customers",
+            tabBarIcon: ({ color, size }: { color: string; size: number }) => (
+              <Ionicons name="people" size={size} color={color} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="estimates"
+          options={{
+            title: "Estimates",
+            tabBarIcon: ({ color, size }: { color: string; size: number }) => (
+              <Ionicons name="document-text" size={size} color={color} />
+            ),
+          }}
+        />
+      </Tabs>
+    </SafeAreaProvider>
   );
 }

--- a/app/customers.tsx
+++ b/app/customers.tsx
@@ -1,20 +1,34 @@
 import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import { Text, StyleSheet, useColorScheme } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function CustomersScreen() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === "dark";
+  const themeColors = {
+    background: isDark ? "#090909" : "#FFFFFF",
+    text: isDark ? "#F9FAFB" : "#1F2933",
+  };
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>👥 Customers Screen</Text>
-    </View>
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: themeColors.background }]}
+    >
+      <Text style={[styles.text, { color: themeColors.text }]}>👥 Customers Screen</Text>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: "center", alignItems: "center" },
-  text: { fontSize: 20, fontWeight: "600" },
-});
-
-const customerstyles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  text: { fontSize: 20 },
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 24,
+  },
+  text: {
+    fontSize: 20,
+    fontWeight: "600",
+    textAlign: "center",
+  },
 });

--- a/app/estimates.tsx
+++ b/app/estimates.tsx
@@ -1,20 +1,34 @@
 import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import { Text, StyleSheet, useColorScheme } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function EstimatesScreen() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === "dark";
+  const themeColors = {
+    background: isDark ? "#090909" : "#FFFFFF",
+    text: isDark ? "#F9FAFB" : "#1F2933",
+  };
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>📄 Estimates Screen</Text>
-    </View>
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: themeColors.background }]}
+    >
+      <Text style={[styles.text, { color: themeColors.text }]}>📄 Estimates Screen</Text>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: "center", alignItems: "center" },
-  text: { fontSize: 20, fontWeight: "600" },
-});
-
-const estimatestyles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  text: { fontSize: 20 },
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 24,
+  },
+  text: {
+    fontSize: 20,
+    fontWeight: "600",
+    textAlign: "center",
+  },
 });

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,11 +1,23 @@
 import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import { Text, StyleSheet, useColorScheme } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function HomeScreen() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === "dark";
+  const themeColors = {
+    background: isDark ? "#090909" : "#FFFFFF",
+    text: isDark ? "#F9FAFB" : "#1F2933",
+  };
+
   return (
-    <View style={homeStyles.container}>
-      <Text style={homeStyles.text}>Welcome to QuickQuote!</Text>
-    </View>
+    <SafeAreaView
+      style={[homeStyles.container, { backgroundColor: themeColors.background }]}
+    >
+      <Text style={[homeStyles.text, { color: themeColors.text }]}>
+        Welcome to QuickQuote!
+      </Text>
+    </SafeAreaView>
   );
 }
 
@@ -14,9 +26,11 @@ const homeStyles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
+    paddingHorizontal: 24,
   },
   text: {
     fontSize: 20,
     fontWeight: "600",
+    textAlign: "center",
   },
 });


### PR DESCRIPTION
## Summary
- adapt the home, customers, and estimates screens to respect the current color scheme
- wrap the content in safe area views and adjust layout spacing for better presentation
- wrap the tab navigator with `SafeAreaProvider` so the safe area spacing is applied correctly

## Testing
- pnpm tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d2ffcc651483238c762dbed0182414