### PR TITLE
Ensure sync waits for SQLite initialization

### DIFF
--- a/quickquote/app/_layout.tsx
+++ b/quickquote/app/_layout.tsx
@@ -6,16 +6,29 @@ import { runSync } from "../lib/sync";
 
 export default function RootLayout() {
   useEffect(() => {
-    // Initialize SQLite on startup
-    initLocalDB();
+    // Initialize SQLite on startup and reuse the promise to avoid race conditions
+    const initPromise = (async () => {
+      try {
+        await initLocalDB();
+      } catch (error) {
+        console.error("Failed to initialize local database", error);
+        throw error;
+      }
+    })();
 
-    // Run sync immediately
-    runSync();
+    const runAfterInit = () =>
+      initPromise
+        .then(() => runSync())
+        .catch((error) => {
+          console.error("Skipping sync because initialization failed", error);
+        });
+
+    runAfterInit();
 
     // Re-run sync when app comes back from background
     const sub = AppState.addEventListener("change", (state) => {
       if (state === "active") {
-        runSync();
+        runAfterInit();
       }
     });
 


### PR DESCRIPTION
## Summary
- ensure the initial sync only runs once the SQLite schema has been created to avoid missing table errors
- reuse the initialization promise for AppState resume syncs and add defensive logging when initialization fails

## Testing
- npm install --legacy-peer-deps *(fails: 403 Forbidden fetching @expo/vector-icons from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d430a6eb4c8323bdd1acc3f5254ee4