### PR TITLE
Pin expo-constants to published SDK 51 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@react-native-picker/picker": "^2.6.1",
     "@supabase/supabase-js": "^2.57.4",
     "expo": "~51.0.28",
-    "expo-constants": "~15.5.4",
+    "expo-constants": "~15.4.6",
     "expo-file-system": "~16.0.9",
     "expo-linking": "~5.0.3",
     "expo-print": "~13.5.2",


### PR DESCRIPTION
## Summary
- set expo-constants to the latest published release compatible with Expo SDK 51 so dependency resolution succeeds

## Testing
- npm install *(fails in container: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d5606ed35c8323a1dfdaba6dc0d974