### PR TITLE
Fix Expo start output under Yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Expo SDK 54 and the matching React Native 0.74 release train.
    yarn start
    ```
 
-The Expo CLI will prompt you to launch the application on a connected device, emulator, or the web.
+The start script disables Yarn's output wrapper so the Expo CLI can display its interactive dashboard
+and QR code correctly. Once Metro has finished bundling, follow the on-screen prompts to launch the
+application on a connected device, emulator, or the web.
 
 ## Daily development workflow
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "expo-router/entry",
   "scripts": {
-    "start": "expo start",
+    "start": "node scripts/start-expo.js",
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web"

--- a/scripts/start-expo.js
+++ b/scripts/start-expo.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+const { spawn } = require("node:child_process");
+let cliPath;
+
+try {
+  cliPath = require.resolve("expo/bin/cli");
+} catch (error) {
+  console.error(
+    "Unable to find the Expo CLI in local dependencies. Make sure you've installed packages with `yarn install`."
+  );
+  process.exit(1);
+}
+
+const child = spawn(process.execPath, [cliPath, ...process.argv.slice(2)], {
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    YARN_WRAP_OUTPUT: "0",
+  },
+});
+
+child.on("error", (error) => {
+  console.error("Failed to launch the Expo CLI", error);
+  process.exitCode = 1;
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
## Summary
- route the Expo start command through a helper script that disables Yarn's output wrapper
- document the Yarn behaviour change so developers know why the QR code now renders correctly

## Testing
- not run (package registry access is blocked in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d5a8ea5aa0832389ce3ff4978940f8