### PR TITLE
Enable in-app estimate editing workflow

### DIFF
--- a/lib/estimates.ts
+++ b/lib/estimates.ts
@@ -21,6 +21,7 @@ export type EstimateRecord = {
   user_id: string;
   customer_id: string;
   date: string | null;
+  status: string | null;
   total: number | null;
   notes: string | null;
   pdf_last_generated_uri: string | null;
@@ -53,6 +54,7 @@ export async function fetchEstimatesWithDetails(): Promise<EstimateRecord[]> {
       e.user_id,
       e.customer_id,
       e.date,
+      e.status,
       e.total,
       e.notes,
       e.pdf_last_generated_uri,


### PR DESCRIPTION
## Summary
- add a full-screen modal editor so contractors can create, update, or delete estimates without leaving the list
- surface quick-entry affordances on the estimates tab and display each estimate's status metadata
- extend the local estimate fetch helper to include status values needed by the editor and UI

## Testing
- yarn tsc --noEmit *(fails: Yarn CLI download blocked by offline sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d1376dfc8323b12225120bedbcc1