### PR TITLE
Add runtime checks for Supabase environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Expo SDK 54 and the matching React Native 0.74 release train.
 
 ## Getting started
 
-1. Copy the provided `.env.example` file to `.env` and fill in your Supabase project details.
+1. Copy the provided `.env.example` file to `.env` and fill in your Supabase project details. The Expo app
+   will refuse to start unless both `EXPO_PUBLIC_SUPABASE_URL` and `EXPO_PUBLIC_SUPABASE_ANON_KEY` are
+   defined, so confirm these values are present before running `yarn start`.
 2. Install dependencies with **Yarn 3.6.4**. We manage Yarn via **Corepack** so every contributor runs the
    same toolchain and avoids the default Yarn 1.22.x that ships with Node installations:
    ```bash

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,8 +1,20 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createClient } from '@supabase/supabase-js';
 
-const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL!;
-const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY!;
+const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!SUPABASE_URL) {
+  throw new Error(
+    'Missing EXPO_PUBLIC_SUPABASE_URL environment variable. Please set it in your .env file or Expo configuration before running the app.'
+  );
+}
+
+if (!SUPABASE_ANON_KEY) {
+  throw new Error(
+    'Missing EXPO_PUBLIC_SUPABASE_ANON_KEY environment variable. Please set it in your .env file or Expo configuration before running the app.'
+  );
+}
 
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   auth: {


### PR DESCRIPTION
## Summary
- replace non-null assertions in the Supabase client with runtime validation of required environment variables
- update the README to remind developers to set the Supabase URL and anon key before starting the app

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6cd8b03988323a31416d061679129