### PR TITLE
Handle missing Supabase configuration gracefully

### DIFF
--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,9 +1,10 @@
 import { Redirect, Stack } from "expo-router";
 import { ActivityIndicator, View } from "react-native";
+import ConfigErrorNotice from "../../components/ConfigErrorNotice";
 import { useAuth } from "../../context/AuthContext";
 
 export default function AuthLayout() {
-  const { session, isLoading } = useAuth();
+  const { session, isLoading, configError } = useAuth();
 
   if (isLoading) {
     return (
@@ -11,6 +12,10 @@ export default function AuthLayout() {
         <ActivityIndicator size="large" />
       </View>
     );
+  }
+
+  if (configError) {
+    return <ConfigErrorNotice message={configError} />;
   }
 
   if (session) {

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,9 +1,10 @@
 import { Redirect } from "expo-router";
 import { ActivityIndicator, View } from "react-native";
+import ConfigErrorNotice from "../components/ConfigErrorNotice";
 import { useAuth } from "../context/AuthContext";
 
 export default function Index() {
-  const { session, isLoading } = useAuth();
+  const { session, isLoading, configError } = useAuth();
 
   if (isLoading) {
     return (
@@ -11,6 +12,10 @@ export default function Index() {
         <ActivityIndicator size="large" />
       </View>
     );
+  }
+
+  if (configError) {
+    return <ConfigErrorNotice message={configError} />;
   }
 
   if (session) {

--- a/components/ConfigErrorNotice.tsx
+++ b/components/ConfigErrorNotice.tsx
@@ -1,0 +1,66 @@
+import { Linking, StyleSheet, Text, View } from "react-native";
+import { useCallback } from "react";
+
+const DOCS_URL =
+  "https://github.com/QuickQuoteApp/QuickQuote/blob/main/README.md#getting-started";
+
+type ConfigErrorNoticeProps = {
+  message: string;
+};
+
+export default function ConfigErrorNotice({
+  message,
+}: ConfigErrorNoticeProps) {
+  const handleOpenDocs = useCallback(() => {
+    Linking.openURL(DOCS_URL).catch(() => {
+      // Ignore failures; Expo Go will surface a toast automatically
+    });
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Configuration needed</Text>
+      <Text style={styles.message}>{message}</Text>
+      <Text style={styles.instructions}>
+        Create a .env file based on .env.example and restart the Expo server.
+      </Text>
+      <Text style={styles.link} onPress={handleOpenDocs}>
+        View setup instructions in the README
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+    backgroundColor: "#0f172a",
+    gap: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "700",
+    color: "#ffffff",
+    textAlign: "center",
+  },
+  message: {
+    fontSize: 16,
+    color: "#cbd5f5",
+    textAlign: "center",
+  },
+  instructions: {
+    fontSize: 16,
+    color: "#e2e8f0",
+    textAlign: "center",
+  },
+  link: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#60a5fa",
+    textAlign: "center",
+    textDecorationLine: "underline",
+  },
+});

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,26 +1,40 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { createClient } from '@supabase/supabase-js';
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
 
 const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL;
 const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
 
-if (!SUPABASE_URL) {
-  throw new Error(
-    'Missing EXPO_PUBLIC_SUPABASE_URL environment variable. Please set it in your .env file or Expo configuration before running the app.'
-  );
+export const isSupabaseConfigured = Boolean(
+  SUPABASE_URL && SUPABASE_ANON_KEY
+);
+
+const MISSING_CONFIG_MESSAGE =
+  "Supabase credentials are not configured. Update your .env file with EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY before continuing.";
+
+function createUnconfiguredClient(): SupabaseClient {
+  const error = new Error(MISSING_CONFIG_MESSAGE);
+  const handler: ProxyHandler<SupabaseClient> = {
+    get() {
+      throw error;
+    },
+    apply() {
+      throw error;
+    },
+  };
+  return new Proxy({} as SupabaseClient, handler);
 }
 
-if (!SUPABASE_ANON_KEY) {
-  throw new Error(
-    'Missing EXPO_PUBLIC_SUPABASE_ANON_KEY environment variable. Please set it in your .env file or Expo configuration before running the app.'
-  );
-}
+export const supabase: SupabaseClient = isSupabaseConfigured
+  ? createClient(SUPABASE_URL!, SUPABASE_ANON_KEY!, {
+      auth: {
+        storage: AsyncStorage,
+        autoRefreshToken: true,
+        persistSession: true,
+        detectSessionInUrl: false,
+      },
+    })
+  : createUnconfiguredClient();
 
-export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-  auth: {
-    storage: AsyncStorage,
-    autoRefreshToken: true,
-    persistSession: true,
-    detectSessionInUrl: false,
-  },
-});
+export const supabaseConfigError = isSupabaseConfigured
+  ? null
+  : MISSING_CONFIG_MESSAGE;


### PR DESCRIPTION
## Summary
- prevent the Supabase client from throwing on startup when environment variables are missing
- expose configuration state through the auth context and show an in-app setup notice when credentials are absent
- add a reusable configuration error notice component that links to the README setup instructions

## Testing
- yarn typecheck *(fails: repository dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6cffbd64c83238d0a64b809623e27