### PR TITLE
Clear delivery logs during bootstrap and sign-out

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -86,6 +86,8 @@ export async function bootstrapUserData(userId: string) {
 
   const db = await openDB();
 
+  // Purge delivery logs so stale deliveries don't reapply after we refresh local data.
+  await db.runAsync("DELETE FROM estimate_delivery_logs");
   await db.runAsync("DELETE FROM sync_queue");
   await db.runAsync("DELETE FROM photos");
   await db.runAsync("DELETE FROM estimate_items");
@@ -165,6 +167,7 @@ export async function bootstrapUserData(userId: string) {
 
 export async function clearLocalData() {
   const db = await openDB();
+  await db.runAsync("DELETE FROM estimate_delivery_logs");
   await db.runAsync("DELETE FROM sync_queue");
   await db.runAsync("DELETE FROM photos");
   await db.runAsync("DELETE FROM estimate_items");


### PR DESCRIPTION
## Summary
- purge estimate delivery logs before repopulating the local database during bootstrap
- clear the delivery log table when signing out to avoid replaying stale deliveries
- document the rationale for the additional purge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e0533de483238b3d9523e9f85590