### PR TITLE
Guard sync against missing Supabase config

### DIFF
--- a/lib/sync.ts
+++ b/lib/sync.ts
@@ -1,4 +1,4 @@
-import { supabase } from "./supabase";
+import { isSupabaseConfigured, supabase, supabaseConfigError } from "./supabase";
 import { getQueuedChanges, clearQueuedChange, Change } from "./sqlite";
 
 // ✅ Process a single change
@@ -41,6 +41,15 @@ async function processChange(change: Change) {
 // ✅ Run full sync
 export async function runSync() {
   console.log("🔄 Running sync...");
+
+  if (!isSupabaseConfigured) {
+    console.warn(
+      "⚠️ Skipping sync because Supabase isn't configured.",
+      supabaseConfigError ??
+        "Provide EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY to enable sync."
+    );
+    return;
+  }
 
   const changes = await getQueuedChanges();
   console.log(`📋 Found ${changes.length} queued change(s)`);


### PR DESCRIPTION
## Summary
- prevent the background sync routine from calling Supabase when the client is not configured
- surface a helpful warning so developers know to supply Supabase environment variables

## Testing
- yarn typecheck *(fails: workspace not installed in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f8b7dcc883238b66dbac97d84226