### PR TITLE
Improve auth bootstrap retry handling

### DIFF
--- a/__tests__/authContext.test.tsx
+++ b/__tests__/authContext.test.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect } from "react";
+import { act, render, waitFor } from "@testing-library/react-native";
+import { Alert, AppState, AppStateStatus } from "react-native";
+import { AuthProvider, useAuth } from "../context/AuthContext";
+import { supabase } from "../lib/supabase";
+import { bootstrapUserData } from "../lib/bootstrap";
+
+jest.mock("../lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn(),
+      onAuthStateChange: jest.fn(),
+      signOut: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../lib/bootstrap", () => ({
+  bootstrapUserData: jest.fn(),
+  clearLocalData: jest.fn(),
+}));
+
+type CapturedAuthValue = ReturnType<typeof useAuth>;
+
+type CaptureProps = {
+  onValue: (value: CapturedAuthValue) => void;
+};
+
+const Capture: React.FC<CaptureProps> = ({ onValue }) => {
+  const value = useAuth();
+
+  useEffect(() => {
+    onValue(value);
+  }, [value, onValue]);
+
+  return null;
+};
+
+const mockGetSession = supabase.auth.getSession as jest.Mock;
+const mockOnAuthStateChange = supabase.auth.onAuthStateChange as jest.Mock;
+const mockBootstrapUserData = bootstrapUserData as jest.Mock;
+const mockAppStateAddEventListener = jest.spyOn(AppState, "addEventListener");
+const mockAlert = jest.spyOn(Alert, "alert");
+
+const appStateListeners: Array<(state: AppStateStatus) => void> = [];
+
+beforeEach(() => {
+  appStateListeners.length = 0;
+  mockGetSession.mockResolvedValue({
+    data: { session: { user: { id: "user-123" } } },
+    error: null,
+  });
+  mockOnAuthStateChange.mockReturnValue({
+    data: { subscription: { unsubscribe: jest.fn() } },
+  });
+  (supabase.auth.signOut as jest.Mock).mockResolvedValue({ error: null });
+  mockBootstrapUserData.mockReset();
+  mockAppStateAddEventListener.mockReset();
+  mockAlert.mockReset();
+  mockAlert.mockImplementation(jest.fn());
+  mockAppStateAddEventListener.mockImplementation((_, listener: (state: AppStateStatus) => void) => {
+    appStateListeners.push(listener);
+    return {
+      remove: () => {
+        const index = appStateListeners.indexOf(listener);
+        if (index !== -1) {
+          appStateListeners.splice(index, 1);
+        }
+      },
+    };
+  });
+});
+
+afterEach(() => {
+  appStateListeners.length = 0;
+});
+
+afterAll(() => {
+  mockAppStateAddEventListener.mockRestore();
+  mockAlert.mockRestore();
+});
+
+describe("AuthProvider bootstrap retry logic", () => {
+  it("retries bootstrapping when the app returns to the foreground", async () => {
+    mockBootstrapUserData
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce(undefined);
+
+    let latestValue: CapturedAuthValue | undefined;
+
+    const handleValue = (value: CapturedAuthValue) => {
+      latestValue = value;
+    };
+
+    render(
+      <AuthProvider>
+        <Capture onValue={handleValue} />
+      </AuthProvider>
+    );
+
+    await waitFor(() => expect(mockBootstrapUserData).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(latestValue?.needsBootstrapRetry).toBe(true));
+
+    await act(async () => {
+      appStateListeners.forEach((listener) => listener("active"));
+    });
+
+    await waitFor(() => expect(mockBootstrapUserData).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(latestValue?.needsBootstrapRetry).toBe(false));
+  });
+
+  it("allows manual bootstrap retries", async () => {
+    mockBootstrapUserData
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce(undefined);
+
+    let latestValue: CapturedAuthValue | undefined;
+
+    const handleValue = (value: CapturedAuthValue) => {
+      latestValue = value;
+    };
+
+    render(
+      <AuthProvider>
+        <Capture onValue={handleValue} />
+      </AuthProvider>
+    );
+
+    await waitFor(() => expect(mockBootstrapUserData).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(latestValue?.needsBootstrapRetry).toBe(true));
+
+    await act(async () => {
+      await latestValue?.retryBootstrap();
+    });
+
+    await waitFor(() => expect(mockBootstrapUserData).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(latestValue?.needsBootstrapRetry).toBe(false));
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@types/react-native": "~0.73.0",
         "babel-preset-expo": "^10.0.2",
         "jest": "^29.7.0",
-        "jest-expo": "^51.0.1",
+        "jest-expo": "^51.0.4",
         "react-test-renderer": "18.2.0",
         "typescript": "~5.3.3"
       }

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",
-    "@types/react": "~18.2.48",
-    "@types/react-native": "~0.73.0",
-    "@types/jest": "^29.5.12",
     "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^13.3.3",
+    "@types/jest": "^29.5.12",
+    "@types/react": "~18.2.48",
+    "@types/react-native": "~0.73.0",
     "babel-preset-expo": "^10.0.2",
     "jest": "^29.7.0",
-    "jest-expo": "^51.0.1",
+    "jest-expo": "^51.0.4",
     "react-test-renderer": "18.2.0",
     "typescript": "~5.3.3"
   },


### PR DESCRIPTION
## Summary
- track bootstrap failures in the auth context and retry when the app returns to the foreground or on manual request
- expose a retry helper while resetting the retry flag after successful bootstraps and add structured logging
- cover the new retry behaviour with unit tests and update the jest-expo dev dependency to ensure the preset is available

## Testing
- npx jest

------
https://chatgpt.com/codex/tasks/task_e_68d7042ca5d083239f1d7838a36a2c76