### PR TITLE
Add URL polyfill import for Supabase client

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,3 +1,4 @@
+import 'react-native-url-polyfill/auto';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createClient } from '@supabase/supabase-js';
 


### PR DESCRIPTION
## Summary
- add the react-native URL polyfill before creating the Supabase client to ensure global URL availability

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d70ddb5308832383021fea4e009948