### PR TITLE
Sanitize estimate queue payloads

### DIFF
--- a/app/(tabs)/estimates/[id].tsx
+++ b/app/(tabs)/estimates/[id].tsx
@@ -27,6 +27,7 @@ import {
   openDB,
   queueChange,
 } from "../../../lib/sqlite";
+import { sanitizeEstimateForQueue } from "../../../lib/estimates";
 import { runSync } from "../../../lib/sync";
 import {
   createPhotoStoragePath,
@@ -339,8 +340,11 @@ export default function EditEstimateScreen() {
       estimateRef.current = updatedEstimate;
       setEstimate(updatedEstimate);
 
-      const { customer_name: _customerName, ...queuePayload } = updatedEstimate;
-      await queueChange("estimates", "update", queuePayload);
+      await queueChange(
+        "estimates",
+        "update",
+        sanitizeEstimateForQueue(updatedEstimate)
+      );
     } catch (error) {
       console.error("Failed to update estimate total", error);
       Alert.alert(
@@ -1119,9 +1123,11 @@ export default function EditEstimateScreen() {
         deleted_at: null,
       };
 
-      const { customer_name: _customerName, ...queuePayload } = updatedEstimate;
-
-      await queueChange("estimates", "update", queuePayload);
+      await queueChange(
+        "estimates",
+        "update",
+        sanitizeEstimateForQueue(updatedEstimate)
+      );
       await runSync();
 
       setEstimate(updatedEstimate);

--- a/app/(tabs)/estimates/index.tsx
+++ b/app/(tabs)/estimates/index.tsx
@@ -10,6 +10,7 @@ import {
   Button,
 } from "react-native";
 import { openDB, queueChange } from "../../../lib/sqlite";
+import { sanitizeEstimateForQueue } from "../../../lib/estimates";
 import { runSync } from "../../../lib/sync";
 
 export type EstimateListItem = {
@@ -140,10 +141,11 @@ export default function EstimatesScreen() {
                   version: nextVersion,
                 };
 
-                const { customer_name: _customerName, ...queuePayload } =
-                  deletedEstimate;
-
-                await queueChange("estimates", "update", queuePayload);
+                await queueChange(
+                  "estimates",
+                  "update",
+                  sanitizeEstimateForQueue(deletedEstimate)
+                );
                 await runSync();
 
                 setEstimates((prev) =>

--- a/lib/__tests__/estimates.test.ts
+++ b/lib/__tests__/estimates.test.ts
@@ -1,0 +1,46 @@
+import { sanitizeEstimateForQueue, ESTIMATE_JOIN_ONLY_KEYS } from "../estimates";
+
+describe("sanitizeEstimateForQueue", () => {
+  it("removes join-only customer columns before queueing", () => {
+    const estimate = {
+      id: "estimate-1",
+      user_id: "user-1",
+      customer_id: "customer-1",
+      customer_name: "Jane Doe",
+      customer_email: "jane@example.com",
+      customer_phone: "555-1234",
+      customer_address: "123 Main St",
+      date: "2024-01-01T00:00:00.000Z",
+      total: 1500,
+      notes: "Test estimate",
+      status: "draft",
+      version: 3,
+      updated_at: "2024-01-02T00:00:00.000Z",
+      deleted_at: null,
+    };
+
+    const sanitized = sanitizeEstimateForQueue(estimate);
+
+    for (const joinKey of ESTIMATE_JOIN_ONLY_KEYS) {
+      expect(sanitized).not.toHaveProperty(joinKey);
+    }
+
+    expect(sanitized).toMatchObject({
+      id: "estimate-1",
+      user_id: "user-1",
+      customer_id: "customer-1",
+      date: "2024-01-01T00:00:00.000Z",
+      total: 1500,
+      notes: "Test estimate",
+      status: "draft",
+      version: 3,
+      updated_at: "2024-01-02T00:00:00.000Z",
+      deleted_at: null,
+    });
+
+    // Ensure the original object is not mutated in case callers reuse it.
+    for (const joinKey of ESTIMATE_JOIN_ONLY_KEYS) {
+      expect(estimate).toHaveProperty(joinKey);
+    }
+  });
+});

--- a/lib/estimates.ts
+++ b/lib/estimates.ts
@@ -1,0 +1,24 @@
+export const ESTIMATE_JOIN_ONLY_KEYS = [
+  "customer_name",
+  "customer_email",
+  "customer_phone",
+  "customer_address",
+] as const;
+
+type EstimateJoinOnlyKey = (typeof ESTIMATE_JOIN_ONLY_KEYS)[number];
+
+type AnyEstimateRecord = Record<string, unknown> &
+  Partial<Record<EstimateJoinOnlyKey, unknown>>;
+
+export function sanitizeEstimateForQueue<T extends AnyEstimateRecord>(
+  estimate: T
+): Omit<T, EstimateJoinOnlyKey> {
+  const sanitized: Record<string, unknown> = { ...estimate };
+
+  for (const key of ESTIMATE_JOIN_ONLY_KEYS) {
+    delete sanitized[key];
+  }
+
+  return sanitized as Omit<T, EstimateJoinOnlyKey>;
+}
+


### PR DESCRIPTION
## Summary
- add a shared helper to strip join-only customer fields from estimate records before queueing
- apply the helper when deleting, updating totals, and saving estimates so only real columns sync
- cover the sanitisation behaviour with a focused regression test

## Testing
- npm test -- --runTestsByPath lib/__tests__/estimates.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d73ca8afd0832389ffe8c98ad22b0f