### PR TITLE
Show bootstrap retry banner

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,12 +1,44 @@
 import { Stack } from "expo-router";
-import { useEffect } from "react";
-import { ActivityIndicator, AppState, View } from "react-native";
+import { useCallback, useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  AppState,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import { AuthProvider, useAuth } from "../context/AuthContext";
 import { initLocalDB } from "../lib/sqlite";
 import { runSync } from "../lib/sync";
 
 function RootNavigator() {
-  const { isLoading } = useAuth();
+  const { isLoading, needsBootstrapRetry, retryBootstrap } = useAuth();
+  const [retryingBootstrap, setRetryingBootstrap] = useState(false);
+
+  useEffect(() => {
+    if (!needsBootstrapRetry) {
+      setRetryingBootstrap(false);
+    }
+  }, [needsBootstrapRetry]);
+
+  const handleRetryBootstrap = useCallback(async () => {
+    if (retryingBootstrap) {
+      return;
+    }
+
+    setRetryingBootstrap(true);
+    console.log("Retry banner pressed: attempting bootstrap recovery");
+
+    try {
+      await retryBootstrap();
+      console.log("Bootstrap recovery succeeded after manual retry");
+    } catch (error) {
+      console.error("Manual bootstrap retry failed from banner", error);
+    } finally {
+      setRetryingBootstrap(false);
+    }
+  }, [retryBootstrap, retryingBootstrap]);
 
   if (isLoading) {
     return (
@@ -16,7 +48,31 @@ function RootNavigator() {
     );
   }
 
-  return <Stack screenOptions={{ headerShown: false }} />;
+  return (
+    <View style={styles.rootContainer}>
+      {needsBootstrapRetry ? (
+        <View style={styles.retryBanner}>
+          <Text style={styles.retryBannerTitle}>We couldn't sync your data.</Text>
+          <Text style={styles.retryBannerMessage}>
+            Check your connection and try again so we can finish downloading the latest
+            information.
+          </Text>
+          <TouchableOpacity
+            accessibilityRole="button"
+            accessibilityLabel="Retry syncing your account"
+            onPress={handleRetryBootstrap}
+            disabled={retryingBootstrap}
+            style={[styles.retryButton, retryingBootstrap && styles.retryButtonDisabled]}
+          >
+            <Text style={styles.retryButtonText}>
+              {retryingBootstrap ? "Retrying…" : "Retry sync"}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      ) : null}
+      <Stack screenOptions={{ headerShown: false }} />
+    </View>
+  );
 }
 
 export default function RootLayout() {
@@ -54,3 +110,43 @@ export default function RootLayout() {
     </AuthProvider>
   );
 }
+
+const styles = StyleSheet.create({
+  rootContainer: {
+    flex: 1,
+  },
+  retryBanner: {
+    backgroundColor: "#FEF3C7",
+    borderBottomColor: "#FCD34D",
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  retryBannerTitle: {
+    color: "#92400E",
+    fontSize: 16,
+    fontWeight: "600",
+    marginBottom: 4,
+  },
+  retryBannerMessage: {
+    color: "#B45309",
+    fontSize: 14,
+    lineHeight: 20,
+    marginBottom: 12,
+  },
+  retryButton: {
+    alignSelf: "flex-start",
+    backgroundColor: "#B45309",
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  retryButtonDisabled: {
+    opacity: 0.6,
+  },
+  retryButtonText: {
+    color: "#FFFBEB",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+});


### PR DESCRIPTION
## Summary
- surface a sync-recovery banner in the root layout when bootstrap fails
- wire the banner button to retryBootstrap and add logging around manual recovery attempts

## Testing
- npm test -- --runTestsByPath

------
https://chatgpt.com/codex/tasks/task_e_68d73f4f37f48323a2f60b287fc71f39