### PR TITLE
Disable new architecture flag for Expo Go compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The project uses [Expo](https://expo.dev/) for local development. After running 
 - **Android emulator:** With an Android emulator running, press `a` in the Expo CLI terminal or run `npm run android` to open the project.
 - **iOS simulator (macOS only):** Press `i` in the Expo CLI terminal or run `npm run ios`.
 - **Web preview:** Press `w` in the Expo CLI terminal or run `npm run web` to launch the Expo web build in a browser.
+- **Architecture compatibility:** Expo Go currently ships without the React Native New Architecture enabled. Keep `newArchEnabled` disabled in `app.config.ts` when developing with Expo Go, otherwise the client will fail to download the JavaScript bundle.
 
 If you change native modules or dependencies, stop the dev server (`Ctrl+C`) and restart it to ensure updates are picked up.
 

--- a/app.config.ts
+++ b/app.config.ts
@@ -9,7 +9,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   orientation: "portrait",
   icon: "./assets/icon.png",
   userInterfaceStyle: "light",
-  newArchEnabled: true,
   splash: {
     image: "./assets/splash-icon.png",
     resizeMode: "contain",


### PR DESCRIPTION
## Summary
- remove the `newArchEnabled` flag so Expo Go can download the development bundle
- document in the README that Expo Go requires the legacy architecture

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d855a5094c8323a2e60fc02ed744ef