### PR TITLE
Run Expo start in offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Follow these steps each time you log in to work on the project:
    ```bash
    npm run start
    ```
-   Use the Expo CLI output to launch the app on your preferred platform (see "Viewing the mobile app" below). Leave the server running while you work so the app reloads as you make changes.
+   The command runs Expo in offline mode so that the Metro bundler starts even when external network requests fail (for example, when the CLI cannot reach Expo's version service). You should now see the familiar QR code and device options in the terminal. Leave the server running while you work so the app reloads as you make changes.
 4. **Implement your changes.** Save files frequently and monitor the terminal for TypeScript or bundler errors.
 5. **Run the automated tests before committing:**
    ```bash

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "expo-router/entry",
   "scripts": {
-    "start": "expo start",
+    "start": "expo start --offline",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",


### PR DESCRIPTION
## Summary
- run the Expo development server in offline mode to avoid network fetch failures that prevented the QR code from appearing
- document the offline start behaviour in the README so developers know why the QR code now shows up reliably

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d872ba34a08323a83063cdea5f4ecb