### PR TITLE
Add ReadableStream polyfill for Expo start

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,1 +1,7 @@
+import { ReadableStream as PolyfillReadableStream } from "web-streams-polyfill/ponyfill";
+
+if (typeof globalThis.ReadableStream === "undefined") {
+  globalThis.ReadableStream = PolyfillReadableStream;
+}
+
 import "expo-router/entry";

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-url-polyfill": "^3.0.0",
-        "uuid": "^9.0.1"
+        "uuid": "^9.0.1",
+        "web-streams-polyfill": "^4.2.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -12097,6 +12098,20 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.2.0.tgz",
+      "integrity": "sha512-0rYDzGOh9EZpig92umN5g5D/9A1Kff7k0/mzPSSCY8jEQeYkgRMoY7LhbXtUCWzLCMX0TUE9aoHkjFNB7D9pfA==",
+      "license": "MIT",
+      "workspaces": [
+        "test/benchmark-test",
+        "test/rollup-test",
+        "test/webpack-test"
+      ],
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-url-polyfill": "^3.0.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "web-streams-polyfill": "^4.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- add a ReadableStream ponyfill so Expo CLI can run under older Node runtimes
- ensure the ponyfill is applied before expo-router initializes

## Testing
- not run (explain why)


------
https://chatgpt.com/codex/tasks/task_e_68d873af89908323bb73c63854cfde2f