### PR TITLE
Fix ReadableStream reference error in tests

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,29 @@
 import "@testing-library/jest-native/extend-expect";
+
+// Node's test environment does not include the WHATWG stream constructors by
+// default.  The Supabase client (via undici) expects `ReadableStream`,
+// `WritableStream`, and `TransformStream` to exist on the global scope.  When
+// they are missing we see runtime errors such as
+// `ReferenceError: ReadableStream is not defined` when the tests exercise code
+// that performs network requests.  The `web-streams-polyfill` package ships a
+// spec-compliant ponyfill that we can safely expose to the globals Jest uses.
+import {
+  ReadableStream as NativeReadableStream,
+  TransformStream as NativeTransformStream,
+  WritableStream as NativeWritableStream,
+} from "node:stream/web";
+
+if (!globalThis.ReadableStream) {
+  // eslint-disable-next-line no-global-assign
+  globalThis.ReadableStream = NativeReadableStream as unknown as typeof globalThis.ReadableStream;
+}
+
+if (!globalThis.WritableStream) {
+  // eslint-disable-next-line no-global-assign
+  globalThis.WritableStream = NativeWritableStream as unknown as typeof globalThis.WritableStream;
+}
+
+if (!globalThis.TransformStream) {
+  // eslint-disable-next-line no-global-assign
+  globalThis.TransformStream = NativeTransformStream as unknown as typeof globalThis.TransformStream;
+}


### PR DESCRIPTION
## Summary
- polyfill the WHATWG stream constructors in the Jest setup using Node's stream/web module to match what undici expects

## Testing
- npm test -- --runTestsByPath __tests__/authContext.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d8747227308323b0b8d74c5b6464cc