### PR TITLE
Allow app to start without Supabase credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ the latest stable Expo SDK (51) and the corresponding React Native 0.74 release.
 ## Getting started
 
 1. Copy the provided `.env.example` file to `.env` and fill in your Supabase project details.
+   Without these values the app boots in a degraded mode and any Supabase call throws an
+   explicit configuration error.
 2. Install dependencies:
    ```bash
    npm install

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,15 +1,47 @@
-import 'react-native-url-polyfill/auto';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { createClient } from '@supabase/supabase-js';
+import "react-native-url-polyfill/auto";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL!;
-const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY!;
+const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-  auth: {
-    storage: AsyncStorage,
-    autoRefreshToken: true,
-    persistSession: true,
-    detectSessionInUrl: false,
-  },
-});
+const missingEnvMessage =
+  "Supabase credentials are not configured. Copy `.env.example` to `.env` " +
+  "and provide EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY.";
+
+const createPlaceholderClient = (): SupabaseClient<any, any, any> => {
+  const throwConfigurationError = () => {
+    throw new Error(missingEnvMessage);
+  };
+
+  const handler: ProxyHandler<any> = {
+    get: (_target, property) => {
+      if (property === "__isPlaceholderClient") {
+        return true;
+      }
+
+      return new Proxy(throwConfigurationError, handler);
+    },
+    apply: () => {
+      throwConfigurationError();
+    },
+  };
+
+  if (process.env.NODE_ENV !== "test") {
+    console.warn(`[QuickQuote] ${missingEnvMessage}`);
+  }
+
+  return new Proxy({}, handler) as SupabaseClient<any, any, any>;
+};
+
+export const supabase =
+  SUPABASE_URL && SUPABASE_ANON_KEY
+    ? createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+        auth: {
+          storage: AsyncStorage,
+          autoRefreshToken: true,
+          persistSession: true,
+          detectSessionInUrl: false,
+        },
+      })
+    : createPlaceholderClient();


### PR DESCRIPTION
## Summary
- create a placeholder Supabase client when the required environment variables are missing so the Expo dev server can boot
- document the degraded-mode behaviour in the setup instructions

## Testing
- `npm test -- --runTestsByPath lib/__tests__/sync.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d8756469f883239af1acc4cde68e2a