### PR TITLE
Fix Expo SQLite bundling errors

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,13 @@
+const { getDefaultConfig } = require("expo/metro-config");
+
+const config = getDefaultConfig(__dirname);
+
+config.resolver.assetExts = config.resolver.assetExts ?? [];
+config.resolver.sourceExts = config.resolver.sourceExts ?? [];
+
+if (!config.resolver.assetExts.includes("wasm")) {
+  config.resolver.assetExts.push("wasm");
+}
+config.resolver.sourceExts = config.resolver.sourceExts.filter((ext) => ext !== "wasm");
+
+module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-native-screens": "~4.16.0",
         "react-native-url-polyfill": "^3.0.0",
         "uuid": "^9.0.1",
+        "wa-sqlite": "^1.0.0",
         "web-streams-polyfill": "^4.2.0"
       },
       "devDependencies": {
@@ -12060,6 +12061,11 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/wa-sqlite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wa-sqlite/-/wa-sqlite-1.0.0.tgz",
+      "integrity": "sha512-Kyybo5/BaJp76z7gDWGk2J6Hthl4NIPsE+swgraEjy3IY6r5zIR02wAs1OJH4XtJp1y3puj3Onp5eMGS0z7nUA=="
     },
     "node_modules/walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-native-screens": "~4.16.0",
     "react-native-url-polyfill": "^3.0.0",
     "uuid": "^9.0.1",
+    "wa-sqlite": "^1.0.0",
     "web-streams-polyfill": "^4.2.0"
   },
   "devDependencies": {

--- a/types/wasm.d.ts
+++ b/types/wasm.d.ts
@@ -1,0 +1,4 @@
+declare module "*.wasm" {
+  const content: ArrayBuffer;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- add the `wa-sqlite` dependency required by `expo-sqlite` when running in Expo Go or on the web
- configure Metro to treat WebAssembly bundles as assets and provide a TypeScript declaration so bundling succeeds

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da79b577488323bb5f06c71d53cfb1