### PR TITLE
Add configurable settings menu with haptics support

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,68 +1,428 @@
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import Slider from "@react-native-community/slider";
 import { useAuth } from "../../context/AuthContext";
+import { useSettings } from "../../context/SettingsContext";
+
+const THEME_OPTIONS = [
+  { label: "Light", value: "light" },
+  { label: "Dark", value: "dark" },
+  { label: "System", value: "system" },
+];
+
+const HAPTIC_LABELS = ["Subtle", "Balanced", "Bold"];
 
 export default function Settings() {
   const { user, signOut, signOutLoading } = useAuth();
+  const {
+    settings,
+    isHydrated,
+    resolvedTheme,
+    setThemePreference,
+    setMaterialMarkup,
+    setLaborMarkup,
+    setHapticsEnabled,
+    setHapticIntensity,
+    setNotificationsEnabled,
+    setAutoSyncEnabled,
+    triggerHaptic,
+    resetToDefaults,
+  } = useSettings();
+
+  const [materialMarkupInput, setMaterialMarkupInput] = useState(settings.materialMarkup.toString());
+  const [laborMarkupInput, setLaborMarkupInput] = useState(settings.laborMarkup.toString());
+
+  useEffect(() => {
+    setMaterialMarkupInput(settings.materialMarkup.toString());
+  }, [settings.materialMarkup]);
+
+  useEffect(() => {
+    setLaborMarkupInput(settings.laborMarkup.toString());
+  }, [settings.laborMarkup]);
+
+  const colors = useMemo(() => {
+    const isDark = resolvedTheme === "dark";
+    return {
+      isDark,
+      background: isDark ? "#0f172a" : "#f1f5f9",
+      card: isDark ? "#1e293b" : "#fff",
+      primaryText: isDark ? "#f8fafc" : "#0f172a",
+      secondaryText: isDark ? "#cbd5f5" : "#475569",
+      border: isDark ? "#334155" : "#e2e8f0",
+      accent: "#2563eb",
+      destructive: "#ef4444",
+    };
+  }, [resolvedTheme]);
+
+  const handleUpdateMarkup = (value: string, updater: (parsed: number) => void) => {
+    const parsed = Number.parseFloat(value);
+    if (Number.isNaN(parsed)) {
+      updater(0);
+      return;
+    }
+
+    updater(Math.max(0, Math.min(parsed, 1000)));
+  };
+
+  const hapticLabel = HAPTIC_LABELS[settings.hapticIntensity] ?? HAPTIC_LABELS[1];
+
+  if (!isHydrated) {
+    return (
+      <View style={[styles.loadingContainer, { backgroundColor: colors.background }]}>
+        <ActivityIndicator size="large" />
+        <Text style={[styles.loadingText, { color: colors.secondaryText }]}>Loading your preferences…</Text>
+      </View>
+    );
+  }
+
+  const themedStyles = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    content: {
+      padding: 24,
+      gap: 20,
+    },
+    section: {
+      backgroundColor: colors.card,
+      borderRadius: 18,
+      padding: 20,
+      gap: 16,
+      shadowColor: colors.isDark ? "#000" : "#0f172a",
+      shadowOpacity: colors.isDark ? 0.4 : 0.08,
+      shadowOffset: { width: 0, height: 6 },
+      shadowRadius: 18,
+      elevation: 4,
+    },
+    sectionHeader: {
+      fontSize: 18,
+      fontWeight: "700",
+      color: colors.primaryText,
+    },
+    sectionDescription: {
+      fontSize: 14,
+      color: colors.secondaryText,
+      lineHeight: 20,
+    },
+    divider: {
+      height: StyleSheet.hairlineWidth,
+      backgroundColor: colors.border,
+      marginVertical: 4,
+    },
+    row: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      gap: 16,
+    },
+    rowLabel: {
+      fontSize: 16,
+      color: colors.primaryText,
+      fontWeight: "500",
+    },
+    rowCaption: {
+      fontSize: 13,
+      color: colors.secondaryText,
+      marginTop: 6,
+      lineHeight: 18,
+    },
+    themeOptions: {
+      flexDirection: "row",
+      gap: 8,
+      flexWrap: "wrap",
+    },
+    themeChip: {
+      paddingVertical: 8,
+      paddingHorizontal: 14,
+      borderRadius: 999,
+      borderWidth: 1,
+      borderColor: colors.border,
+      backgroundColor: colors.isDark ? "rgba(148, 163, 184, 0.08)" : "#f8fafc",
+    },
+    themeChipActive: {
+      borderColor: colors.accent,
+      backgroundColor: colors.isDark ? "rgba(37, 99, 235, 0.2)" : "rgba(37, 99, 235, 0.08)",
+    },
+    themeChipText: {
+      color: colors.primaryText,
+      fontWeight: "600",
+    },
+    textFieldContainer: {
+      flex: 1,
+    },
+    textField: {
+      borderWidth: 1,
+      borderColor: colors.border,
+      borderRadius: 12,
+      paddingHorizontal: 12,
+      paddingVertical: 10,
+      fontSize: 16,
+      color: colors.primaryText,
+      backgroundColor: colors.isDark ? "rgba(15, 23, 42, 0.7)" : "#f8fafc",
+    },
+    percentSuffix: {
+      fontSize: 16,
+      fontWeight: "600",
+      color: colors.secondaryText,
+      marginLeft: 8,
+    },
+    sliderLabelRow: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      marginTop: 6,
+    },
+    sliderLabel: {
+      fontSize: 13,
+      color: colors.secondaryText,
+    },
+    destructiveButton: {
+      backgroundColor: colors.destructive,
+      borderRadius: 14,
+      paddingVertical: 14,
+      alignItems: "center",
+    },
+    destructiveText: {
+      color: "#fff",
+      fontSize: 16,
+      fontWeight: "600",
+    },
+    buttonDisabled: {
+      opacity: 0.6,
+    },
+    footerActions: {
+      gap: 16,
+    },
+    resetButton: {
+      borderRadius: 14,
+      paddingVertical: 14,
+      alignItems: "center",
+      borderWidth: 1,
+      borderColor: colors.border,
+      backgroundColor: colors.isDark ? "rgba(148, 163, 184, 0.08)" : "#fff",
+    },
+    resetText: {
+      color: colors.primaryText,
+      fontSize: 16,
+      fontWeight: "600",
+    },
+  });
+
+  const handleSignOut = () => {
+    triggerHaptic();
+    signOut();
+  };
 
   return (
-    <View style={styles.container}>
-      <View style={styles.card}>
-        <Text style={styles.title}>Account</Text>
-        <Text style={styles.label}>Signed in as</Text>
-        <Text style={styles.value}>{user?.email ?? "Unknown"}</Text>
-        <Pressable style={[styles.button, signOutLoading && styles.buttonDisabled]} onPress={signOut} disabled={signOutLoading}>
-          <Text style={styles.buttonText}>{signOutLoading ? "Signing out..." : "Sign out"}</Text>
-        </Pressable>
-      </View>
+    <View style={themedStyles.container}>
+      <ScrollView contentContainerStyle={themedStyles.content} showsVerticalScrollIndicator={false}>
+        <View style={themedStyles.section}>
+          <Text style={themedStyles.sectionHeader}>Appearance</Text>
+          <Text style={themedStyles.sectionDescription}>
+            Choose how QuickQuote should look. You can follow your device, or force a specific mode.
+          </Text>
+          <View style={themedStyles.themeOptions}>
+            {THEME_OPTIONS.map((option) => {
+              const isActive = settings.themePreference === option.value;
+              return (
+                <Pressable
+                  key={option.value}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Switch to ${option.label.toLowerCase()} theme`}
+                  onPress={() => {
+                    setThemePreference(option.value);
+                    triggerHaptic();
+                  }}
+                  style={[themedStyles.themeChip, isActive && themedStyles.themeChipActive]}
+                >
+                  <Text style={themedStyles.themeChipText}>{option.label}</Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </View>
+
+        <View style={themedStyles.section}>
+          <Text style={themedStyles.sectionHeader}>Markup defaults</Text>
+          <Text style={themedStyles.sectionDescription}>
+            Adjust the default markup percentages for new estimates. You can still override these on a per-estimate
+            basis.
+          </Text>
+          <View>
+            <Text style={themedStyles.rowLabel}>Material markup</Text>
+            <View style={styles.inputRow}>
+              <View style={themedStyles.textFieldContainer}>
+                <TextInput
+                  value={materialMarkupInput}
+                  onChangeText={setMaterialMarkupInput}
+                  onBlur={() => handleUpdateMarkup(materialMarkupInput, setMaterialMarkup)}
+                  keyboardType="numeric"
+                  returnKeyType="done"
+                  style={themedStyles.textField}
+                  placeholder="0"
+                  placeholderTextColor={colors.secondaryText}
+                />
+              </View>
+              <Text style={themedStyles.percentSuffix}>%</Text>
+            </View>
+          </View>
+          <View style={styles.fieldSpacer} />
+          <View>
+            <Text style={themedStyles.rowLabel}>Labor markup</Text>
+            <View style={styles.inputRow}>
+              <View style={themedStyles.textFieldContainer}>
+                <TextInput
+                  value={laborMarkupInput}
+                  onChangeText={setLaborMarkupInput}
+                  onBlur={() => handleUpdateMarkup(laborMarkupInput, setLaborMarkup)}
+                  keyboardType="numeric"
+                  returnKeyType="done"
+                  style={themedStyles.textField}
+                  placeholder="0"
+                  placeholderTextColor={colors.secondaryText}
+                />
+              </View>
+              <Text style={themedStyles.percentSuffix}>%</Text>
+            </View>
+          </View>
+        </View>
+
+        <View style={themedStyles.section}>
+          <Text style={themedStyles.sectionHeader}>Haptics</Text>
+          <Text style={themedStyles.sectionDescription}>
+            Feel a tactile tap when you interact with buttons and toggles. Tune the intensity to what feels best.
+          </Text>
+          <View style={themedStyles.row}>
+            <View style={{ flex: 1 }}>
+              <Text style={themedStyles.rowLabel}>Enable haptic feedback</Text>
+              <Text style={themedStyles.rowCaption}>Disabling this turns off vibration for buttons throughout the app.</Text>
+            </View>
+            <Switch
+              value={settings.hapticsEnabled}
+              onValueChange={(value) => {
+                setHapticsEnabled(value);
+                triggerHaptic();
+              }}
+              thumbColor={settings.hapticsEnabled ? colors.accent : undefined}
+            />
+          </View>
+          <View>
+            <Text style={themedStyles.rowLabel}>Tap intensity</Text>
+            <Slider
+              minimumValue={0}
+              maximumValue={2}
+              step={1}
+              value={settings.hapticIntensity}
+              onValueChange={(value) => setHapticIntensity(value as 0 | 1 | 2)}
+              onSlidingComplete={() => triggerHaptic()}
+              minimumTrackTintColor={colors.accent}
+              maximumTrackTintColor={colors.border}
+              thumbTintColor={colors.accent}
+            />
+            <View style={themedStyles.sliderLabelRow}>
+              <Text style={themedStyles.sliderLabel}>Subtle</Text>
+              <Text style={[themedStyles.sliderLabel, { color: colors.primaryText, fontWeight: "600" }]}>{hapticLabel}</Text>
+              <Text style={themedStyles.sliderLabel}>Bold</Text>
+            </View>
+          </View>
+        </View>
+
+        <View style={themedStyles.section}>
+          <Text style={themedStyles.sectionHeader}>General</Text>
+          <View style={themedStyles.row}>
+            <View style={{ flex: 1 }}>
+              <Text style={themedStyles.rowLabel}>Email notifications</Text>
+              <Text style={themedStyles.rowCaption}>Get a daily digest of new estimates and approvals.</Text>
+            </View>
+            <Switch
+              value={settings.notificationsEnabled}
+              onValueChange={(value) => {
+                setNotificationsEnabled(value);
+                triggerHaptic();
+              }}
+              thumbColor={settings.notificationsEnabled ? colors.accent : undefined}
+            />
+          </View>
+          <View style={styles.rowSeparator} />
+          <View style={themedStyles.row}>
+            <View style={{ flex: 1 }}>
+              <Text style={themedStyles.rowLabel}>Auto-sync data</Text>
+              <Text style={themedStyles.rowCaption}>Automatically sync estimates when QuickQuote opens.</Text>
+            </View>
+            <Switch
+              value={settings.autoSyncEnabled}
+              onValueChange={(value) => {
+                setAutoSyncEnabled(value);
+                triggerHaptic();
+              }}
+              thumbColor={settings.autoSyncEnabled ? colors.accent : undefined}
+            />
+          </View>
+        </View>
+
+        <View style={themedStyles.section}>
+          <Text style={themedStyles.sectionHeader}>Account</Text>
+          <Text style={themedStyles.sectionDescription}>You are signed in as</Text>
+          <Text style={[themedStyles.rowLabel, { fontSize: 17 }]}>{user?.email ?? "Unknown"}</Text>
+          <View style={themedStyles.footerActions}>
+            <Pressable
+              onPress={() => {
+                triggerHaptic();
+                resetToDefaults();
+              }}
+              style={themedStyles.resetButton}
+              accessibilityRole="button"
+              accessibilityLabel="Reset all preferences"
+            >
+              <Text style={themedStyles.resetText}>Reset preferences</Text>
+            </Pressable>
+            <Pressable
+              style={[themedStyles.destructiveButton, signOutLoading && themedStyles.buttonDisabled]}
+              onPress={handleSignOut}
+              disabled={signOutLoading}
+              accessibilityRole="button"
+              accessibilityLabel="Sign out of QuickQuote"
+            >
+              <Text style={themedStyles.destructiveText}>{signOutLoading ? "Signing out…" : "Sign out"}</Text>
+            </Pressable>
+          </View>
+        </View>
+      </ScrollView>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  loadingContainer: {
     flex: 1,
-    backgroundColor: "#f1f5f9",
-    padding: 24,
-    justifyContent: "flex-start",
-  },
-  card: {
-    backgroundColor: "#fff",
-    borderRadius: 16,
-    padding: 24,
+    alignItems: "center",
+    justifyContent: "center",
     gap: 12,
-    shadowColor: "#000",
-    shadowOpacity: 0.08,
-    shadowOffset: { width: 0, height: 4 },
-    shadowRadius: 10,
-    elevation: 3,
   },
-  title: {
-    fontSize: 22,
-    fontWeight: "700",
-    color: "#0f172a",
+  loadingText: {
+    fontSize: 16,
   },
-  label: {
-    fontSize: 14,
-    color: "#475569",
-  },
-  value: {
-    fontSize: 18,
-    fontWeight: "600",
-    color: "#0f172a",
-  },
-  button: {
-    marginTop: 16,
-    backgroundColor: "#ef4444",
-    paddingVertical: 14,
-    borderRadius: 12,
+  inputRow: {
+    marginTop: 8,
+    flexDirection: "row",
     alignItems: "center",
   },
-  buttonDisabled: {
-    opacity: 0.6,
+  fieldSpacer: {
+    height: 12,
   },
-  buttonText: {
-    color: "#fff",
-    fontSize: 16,
-    fontWeight: "600",
+  rowSeparator: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: "rgba(148, 163, 184, 0.4)",
+    marginVertical: 4,
   },
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -9,6 +9,7 @@ import {
   View,
 } from "react-native";
 import { AuthProvider, useAuth } from "../context/AuthContext";
+import { SettingsProvider } from "../context/SettingsContext";
 import { initLocalDB } from "../lib/sqlite";
 import { runSync } from "../lib/sync";
 
@@ -105,9 +106,11 @@ export default function RootLayout() {
   }, []);
 
   return (
-    <AuthProvider>
-      <RootNavigator />
-    </AuthProvider>
+    <SettingsProvider>
+      <AuthProvider>
+        <RootNavigator />
+      </AuthProvider>
+    </SettingsProvider>
   );
 }
 

--- a/context/SettingsContext.tsx
+++ b/context/SettingsContext.tsx
@@ -1,0 +1,245 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Appearance, ColorSchemeName } from "react-native";
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import * as Haptics from "expo-haptics";
+
+export type ThemePreference = "light" | "dark" | "system";
+
+export type HapticIntensity = 0 | 1 | 2;
+
+export interface SettingsState {
+  themePreference: ThemePreference;
+  materialMarkup: number;
+  laborMarkup: number;
+  hapticsEnabled: boolean;
+  hapticIntensity: HapticIntensity;
+  notificationsEnabled: boolean;
+  autoSyncEnabled: boolean;
+}
+
+interface SettingsContextValue {
+  settings: SettingsState;
+  isHydrated: boolean;
+  resolvedTheme: "light" | "dark";
+  setThemePreference: (preference: ThemePreference) => void;
+  setMaterialMarkup: (value: number) => void;
+  setLaborMarkup: (value: number) => void;
+  setHapticsEnabled: (value: boolean) => void;
+  setHapticIntensity: (value: HapticIntensity) => void;
+  setNotificationsEnabled: (value: boolean) => void;
+  setAutoSyncEnabled: (value: boolean) => void;
+  triggerHaptic: (style?: Haptics.ImpactFeedbackStyle) => void;
+  resetToDefaults: () => void;
+}
+
+const DEFAULT_SETTINGS: SettingsState = {
+  themePreference: "system",
+  materialMarkup: 15,
+  laborMarkup: 20,
+  hapticsEnabled: true,
+  hapticIntensity: 1,
+  notificationsEnabled: true,
+  autoSyncEnabled: true,
+};
+
+const STORAGE_KEY = "@quickquote/settings";
+
+const SettingsContext = createContext<SettingsContextValue | undefined>(undefined);
+
+export function SettingsProvider({ children }: { children: ReactNode }) {
+  const [settings, setSettings] = useState<SettingsState>(DEFAULT_SETTINGS);
+  const [isHydrated, setIsHydrated] = useState(false);
+  const [systemTheme, setSystemTheme] = useState<ColorSchemeName>(Appearance.getColorScheme());
+  const hydrationRef = useRef(false);
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const stored = await AsyncStorage.getItem(STORAGE_KEY);
+        if (stored) {
+          const parsed = JSON.parse(stored) as Partial<SettingsState>;
+          setSettings((current) => ({ ...current, ...parsed }));
+        }
+      } catch (error) {
+        console.error("Failed to load settings from storage", error);
+      } finally {
+        hydrationRef.current = true;
+        setIsHydrated(true);
+      }
+    };
+
+    loadSettings();
+  }, []);
+
+  useEffect(() => {
+    const subscription = Appearance.addChangeListener(({ colorScheme }) => {
+      setSystemTheme(colorScheme);
+    });
+
+    return () => subscription.remove();
+  }, []);
+
+  useEffect(() => {
+    if (!hydrationRef.current) {
+      return;
+    }
+
+    const persist = async () => {
+      try {
+        await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+      } catch (error) {
+        console.error("Failed to persist settings", error);
+      }
+    };
+
+    persist();
+  }, [settings]);
+
+  const resolvedTheme = useMemo<"light" | "dark">(() => {
+    if (settings.themePreference === "system") {
+      return systemTheme === "dark" ? "dark" : "light";
+    }
+
+    return settings.themePreference;
+  }, [settings.themePreference, systemTheme]);
+
+  const updateSettings = useCallback((updater: Partial<SettingsState> | ((prev: SettingsState) => SettingsState)) => {
+    setSettings((prev) => {
+      if (typeof updater === "function") {
+        return updater(prev);
+      }
+
+      return { ...prev, ...updater };
+    });
+  }, []);
+
+  const setThemePreference = useCallback(
+    (preference: ThemePreference) => {
+      updateSettings({ themePreference: preference });
+    },
+    [updateSettings]
+  );
+
+  const setMaterialMarkup = useCallback(
+    (value: number) => {
+      updateSettings({ materialMarkup: Number.isFinite(value) ? Math.max(0, value) : 0 });
+    },
+    [updateSettings]
+  );
+
+  const setLaborMarkup = useCallback(
+    (value: number) => {
+      updateSettings({ laborMarkup: Number.isFinite(value) ? Math.max(0, value) : 0 });
+    },
+    [updateSettings]
+  );
+
+  const setHapticsEnabled = useCallback(
+    (value: boolean) => {
+      updateSettings({ hapticsEnabled: value });
+    },
+    [updateSettings]
+  );
+
+  const setHapticIntensity = useCallback(
+    (value: HapticIntensity) => {
+      updateSettings({ hapticIntensity: Math.min(2, Math.max(0, Math.round(value))) as HapticIntensity });
+    },
+    [updateSettings]
+  );
+
+  const setNotificationsEnabled = useCallback(
+    (value: boolean) => {
+      updateSettings({ notificationsEnabled: value });
+    },
+    [updateSettings]
+  );
+
+  const setAutoSyncEnabled = useCallback(
+    (value: boolean) => {
+      updateSettings({ autoSyncEnabled: value });
+    },
+    [updateSettings]
+  );
+
+  const triggerHaptic = useCallback(
+    (style?: Haptics.ImpactFeedbackStyle) => {
+      if (!settings.hapticsEnabled) {
+        return;
+      }
+
+      const normalizedIntensity = Math.min(2, Math.max(0, Math.round(settings.hapticIntensity)));
+      const inferredStyle = (() => {
+        switch (normalizedIntensity) {
+          case 0:
+            return Haptics.ImpactFeedbackStyle.Light;
+          case 2:
+            return Haptics.ImpactFeedbackStyle.Heavy;
+          default:
+            return Haptics.ImpactFeedbackStyle.Medium;
+        }
+      })();
+
+      Haptics.impactAsync(style ?? inferredStyle).catch((error) => {
+        console.warn("Unable to trigger haptic feedback", error);
+      });
+    },
+    [settings.hapticsEnabled, settings.hapticIntensity]
+  );
+
+  const resetToDefaults = useCallback(() => {
+    updateSettings(DEFAULT_SETTINGS);
+  }, [updateSettings]);
+
+  const value = useMemo<SettingsContextValue>(
+    () => ({
+      settings,
+      isHydrated,
+      resolvedTheme,
+      setThemePreference,
+      setMaterialMarkup,
+      setLaborMarkup,
+      setHapticsEnabled,
+      setHapticIntensity,
+      setNotificationsEnabled,
+      setAutoSyncEnabled,
+      triggerHaptic,
+      resetToDefaults,
+    }),
+    [
+      isHydrated,
+      resolvedTheme,
+      setAutoSyncEnabled,
+      setHapticIntensity,
+      setHapticsEnabled,
+      setLaborMarkup,
+      setMaterialMarkup,
+      setNotificationsEnabled,
+      setThemePreference,
+      settings,
+      triggerHaptic,
+      resetToDefaults,
+    ]
+  );
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
+}
+
+export function useSettings() {
+  const context = useContext(SettingsContext);
+
+  if (!context) {
+    throw new Error("useSettings must be used within a SettingsProvider");
+  }
+
+  return context;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "@expo/vector-icons": "^15.0.2",
         "@react-native-async-storage/async-storage": "~2.2.0",
+        "@react-native-community/slider": "^5.0.0",
         "@react-native-picker/picker": "^2.11.1",
         "@supabase/supabase-js": "^2.58.0",
         "expo": "~54.0.10",
         "expo-constants": "~18.0.9",
         "expo-file-system": "~19.0.15",
+        "expo-haptics": "~13.0.0",
         "expo-image-picker": "~17.0.8",
         "expo-linking": "~8.0.8",
         "expo-print": "~15.0.7",
@@ -3092,6 +3094,12 @@
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
+    "node_modules/@react-native-community/slider": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-5.0.1.tgz",
+      "integrity": "sha512-K3JRWkIW4wQ79YJ6+BPZzp1SamoikxfPRw7Yw4B4PElEQmqZFrmH9M5LxvIo460/3QSrZF/wCgi3qizJt7g/iw==",
+      "license": "MIT"
+    },
     "node_modules/@react-native-picker/picker": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.11.2.tgz",
@@ -6052,6 +6060,15 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-haptics": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-13.0.1.tgz",
+      "integrity": "sha512-qG0EOLDE4bROVT3DtUSyV9g3iB3YFu9j3711X7SNNEnBDXc+2/p3wGDPTnJvPW0ao6HG3/McAOrBQA5hVSdWng==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-image-loader": {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",
     "@react-native-async-storage/async-storage": "~2.2.0",
+    "@react-native-community/slider": "^5.0.0",
     "@react-native-picker/picker": "^2.11.1",
     "@supabase/supabase-js": "^2.58.0",
     "expo": "~54.0.10",
     "expo-constants": "~18.0.9",
     "expo-file-system": "~19.0.15",
+    "expo-haptics": "~13.0.0",
     "expo-image-picker": "~17.0.8",
     "expo-linking": "~8.0.8",
     "expo-print": "~15.0.7",


### PR DESCRIPTION
## Summary
- add a settings context to persist theme, markup, and feedback preferences across sessions
- redesign the settings screen with appearance controls, markup inputs, toggles, and haptic intensity slider
- introduce haptics and slider dependencies to support tactile feedback customization

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68da8882526083238ade97f3e7339d66