### PR TITLE
Improve item modal stability in estimate forms

### DIFF
--- a/app/(tabs)/estimates/index.tsx
+++ b/app/(tabs)/estimates/index.tsx
@@ -23,6 +23,13 @@ export type EstimateListItem = {
   customer_address: string | null;
   date: string | null;
   total: number | null;
+  material_total: number | null;
+  labor_hours: number | null;
+  labor_rate: number | null;
+  labor_total: number | null;
+  subtotal: number | null;
+  tax_rate: number | null;
+  tax_total: number | null;
   notes: string | null;
   status: string | null;
   version: number | null;
@@ -65,6 +72,7 @@ export default function EstimatesScreen() {
         const db = await openDB();
         const rows = await db.getAllAsync<EstimateListItem>(
           `SELECT e.id, e.user_id, e.customer_id, e.date, e.total, e.notes, e.status, e.version, e.updated_at, e.deleted_at,
+                  e.material_total, e.labor_hours, e.labor_rate, e.labor_total, e.subtotal, e.tax_rate, e.tax_total,
                   c.name AS customer_name,
                   c.email AS customer_email,
                   c.phone AS customer_phone,
@@ -187,6 +195,12 @@ export default function EstimatesScreen() {
           </Text>
           <Text style={{ color: "#555", marginTop: 2 }}>
             Total: {formatCurrency(item.total)}
+          </Text>
+          <Text style={{ color: "#555", marginTop: 2 }}>
+            Labor: {formatCurrency(item.labor_total ?? 0)}
+          </Text>
+          <Text style={{ color: "#555", marginTop: 2 }}>
+            Materials: {formatCurrency(item.material_total ?? 0)}
           </Text>
           {item.date ? (
             <Text style={{ color: "#777", marginTop: 2 }}>

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -30,6 +30,7 @@ export default function Settings() {
     setThemePreference,
     setMaterialMarkup,
     setLaborMarkup,
+    setHourlyRate,
     setHapticsEnabled,
     setHapticIntensity,
     setNotificationsEnabled,
@@ -40,6 +41,7 @@ export default function Settings() {
 
   const [materialMarkupInput, setMaterialMarkupInput] = useState(settings.materialMarkup.toString());
   const [laborMarkupInput, setLaborMarkupInput] = useState(settings.laborMarkup.toString());
+  const [hourlyRateInput, setHourlyRateInput] = useState(settings.hourlyRate.toFixed(2));
 
   useEffect(() => {
     setMaterialMarkupInput(settings.materialMarkup.toString());
@@ -48,6 +50,10 @@ export default function Settings() {
   useEffect(() => {
     setLaborMarkupInput(settings.laborMarkup.toString());
   }, [settings.laborMarkup]);
+
+  useEffect(() => {
+    setHourlyRateInput(settings.hourlyRate.toFixed(2));
+  }, [settings.hourlyRate]);
 
   const colors = useMemo(() => {
     const isDark = resolvedTheme === "dark";
@@ -71,6 +77,16 @@ export default function Settings() {
     }
 
     updater(Math.max(0, Math.min(parsed, 1000)));
+  };
+
+  const handleUpdateHourlyRate = (value: string) => {
+    const parsed = Number.parseFloat(value.replace(/[^0-9.]/g, ""));
+    if (Number.isNaN(parsed)) {
+      setHourlyRate(0);
+      return;
+    }
+
+    setHourlyRate(Math.max(0, Math.round(parsed * 100) / 100));
   };
 
   const hapticLabel = HAPTIC_LABELS[settings.hapticIntensity] ?? HAPTIC_LABELS[1];
@@ -175,6 +191,12 @@ export default function Settings() {
       fontWeight: "600",
       color: colors.secondaryText,
       marginLeft: 8,
+    },
+    currencyPrefix: {
+      fontSize: 16,
+      fontWeight: "600",
+      color: colors.secondaryText,
+      marginRight: 8,
     },
     sliderLabelRow: {
       flexDirection: "row",
@@ -293,6 +315,32 @@ export default function Settings() {
                 />
               </View>
               <Text style={themedStyles.percentSuffix}>%</Text>
+            </View>
+          </View>
+        </View>
+
+        <View style={themedStyles.section}>
+          <Text style={themedStyles.sectionHeader}>Labor defaults</Text>
+          <Text style={themedStyles.sectionDescription}>
+            Set the standard hourly rate used when calculating project labor totals. You can adjust this on individual
+            estimates when needed.
+          </Text>
+          <View>
+            <Text style={themedStyles.rowLabel}>Hourly rate</Text>
+            <View style={styles.inputRow}>
+              <Text style={themedStyles.currencyPrefix}>$</Text>
+              <View style={[themedStyles.textFieldContainer, { flex: 0, flexGrow: 1 }]}>
+                <TextInput
+                  value={hourlyRateInput}
+                  onChangeText={setHourlyRateInput}
+                  onBlur={() => handleUpdateHourlyRate(hourlyRateInput)}
+                  keyboardType="decimal-pad"
+                  returnKeyType="done"
+                  style={themedStyles.textField}
+                  placeholder="0.00"
+                  placeholderTextColor={colors.secondaryText}
+                />
+              </View>
             </View>
           </View>
         </View>

--- a/components/EstimateItemForm.tsx
+++ b/components/EstimateItemForm.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Alert, Button, Text, TextInput, View } from "react-native";
+import { Alert, Button, Switch, Text, TextInput, View } from "react-native";
+import { Picker } from "@react-native-picker/picker";
 
 export type EstimateItemFormValues = {
   description: string;
@@ -8,13 +9,28 @@ export type EstimateItemFormValues = {
   total: number;
 };
 
+export type EstimateItemTemplate = {
+  id: string;
+  description: string;
+  unit_price: number;
+  default_quantity?: number | null;
+};
+
+export type EstimateItemFormSubmit = {
+  values: EstimateItemFormValues;
+  saveToLibrary: boolean;
+  templateId: string | null;
+};
+
 type EstimateItemFormProps = {
   initialValue?: {
     description: string;
     quantity: number;
     unit_price: number;
   };
-  onSubmit: (values: EstimateItemFormValues) => void;
+  initialTemplateId?: string | null;
+  templates?: EstimateItemTemplate[];
+  onSubmit: (payload: EstimateItemFormSubmit) => Promise<void> | void;
   onCancel: () => void;
   submitLabel?: string;
 };
@@ -45,6 +61,8 @@ function formatCurrency(value: number): string {
 
 export default function EstimateItemForm({
   initialValue,
+  initialTemplateId = null,
+  templates = [],
   onSubmit,
   onCancel,
   submitLabel = "Save Item",
@@ -56,6 +74,11 @@ export default function EstimateItemForm({
   const [unitPriceText, setUnitPriceText] = useState(
     initialValue ? String(initialValue.unit_price) : "0"
   );
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(
+    initialTemplateId ?? null
+  );
+  const [saveToLibrary, setSaveToLibrary] = useState<boolean>(true);
+  const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     if (!initialValue) {
@@ -66,13 +89,41 @@ export default function EstimateItemForm({
     setUnitPriceText(String(initialValue.unit_price));
   }, [initialValue]);
 
+  useEffect(() => {
+    setSelectedTemplateId(initialTemplateId ?? null);
+    setSaveToLibrary(true);
+  }, [initialTemplateId]);
+
+  const templateMap = useMemo(() => {
+    return templates.reduce<Record<string, EstimateItemTemplate>>((acc, template) => {
+      acc[template.id] = template;
+      return acc;
+    }, {});
+  }, [templates]);
+
   const total = useMemo(() => {
     const quantity = parseQuantity(quantityText);
     const unitPrice = parseCurrency(unitPriceText);
     return Math.round(quantity * unitPrice * 100) / 100;
   }, [quantityText, unitPriceText]);
 
-  const handleSubmit = () => {
+  const applyTemplate = (templateId: string | null) => {
+    if (!templateId) {
+      return;
+    }
+    const template = templateMap[templateId];
+    if (!template) {
+      return;
+    }
+
+    setDescription(template.description);
+    setUnitPriceText(template.unit_price.toString());
+    if (template.default_quantity && template.default_quantity > 0) {
+      setQuantityText(String(template.default_quantity));
+    }
+  };
+
+  const handleSubmit = async () => {
     const trimmedDescription = description.trim();
     if (!trimmedDescription) {
       Alert.alert("Validation", "Please enter a description for the item.");
@@ -87,16 +138,57 @@ export default function EstimateItemForm({
 
     const unitPrice = parseCurrency(unitPriceText);
 
-    onSubmit({
-      description: trimmedDescription,
-      quantity,
-      unit_price: unitPrice,
-      total,
-    });
+    const payload: EstimateItemFormSubmit = {
+      values: {
+        description: trimmedDescription,
+        quantity,
+        unit_price: unitPrice,
+        total,
+      },
+      saveToLibrary,
+      templateId: selectedTemplateId,
+    };
+
+    try {
+      setSubmitting(true);
+      await onSubmit(payload);
+    } catch (error) {
+      console.error("Failed to save estimate item", error);
+      Alert.alert("Error", "Unable to save this item. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
     <View style={{ gap: 12 }}>
+      {templates.length > 0 ? (
+        <View style={{ gap: 6 }}>
+          <Text style={{ fontWeight: "600" }}>Saved items</Text>
+          <View style={{ borderWidth: 1, borderRadius: 8 }}>
+            <Picker
+              selectedValue={selectedTemplateId ?? ""}
+              onValueChange={(value) => {
+                const nextValue = value ? String(value) : "";
+                const normalized = nextValue ? nextValue : null;
+                setSelectedTemplateId(normalized);
+                setSaveToLibrary(Boolean(normalized));
+                applyTemplate(normalized);
+              }}
+            >
+              <Picker.Item label="Select a saved item" value="" />
+              {templates.map((template) => (
+                <Picker.Item
+                  key={template.id}
+                  label={template.description}
+                  value={template.id}
+                />
+              ))}
+            </Picker>
+          </View>
+        </View>
+      ) : null}
+
       <View style={{ gap: 6 }}>
         <Text style={{ fontWeight: "600" }}>Description</Text>
         <TextInput
@@ -134,12 +226,29 @@ export default function EstimateItemForm({
         <Text>{formatCurrency(total)}</Text>
       </View>
 
+      <View
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          paddingVertical: 4,
+        }}
+      >
+        <View style={{ flex: 1, paddingRight: 12 }}>
+          <Text style={{ fontWeight: "600" }}>Save for future use</Text>
+          <Text style={{ color: "#555", marginTop: 2, fontSize: 12 }}>
+            Adds this item to your library so you can quickly reuse or update it later.
+          </Text>
+        </View>
+        <Switch value={saveToLibrary} onValueChange={setSaveToLibrary} />
+      </View>
+
       <View style={{ flexDirection: "row", gap: 12 }}>
         <View style={{ flex: 1 }}>
-          <Button title="Cancel" onPress={onCancel} />
+          <Button title="Cancel" onPress={onCancel} disabled={submitting} />
         </View>
         <View style={{ flex: 1 }}>
-          <Button title={submitLabel} onPress={handleSubmit} />
+          <Button title={submitLabel} onPress={handleSubmit} disabled={submitting} />
         </View>
       </View>
     </View>

--- a/context/SettingsContext.tsx
+++ b/context/SettingsContext.tsx
@@ -20,6 +20,7 @@ export interface SettingsState {
   themePreference: ThemePreference;
   materialMarkup: number;
   laborMarkup: number;
+  hourlyRate: number;
   hapticsEnabled: boolean;
   hapticIntensity: HapticIntensity;
   notificationsEnabled: boolean;
@@ -33,6 +34,7 @@ interface SettingsContextValue {
   setThemePreference: (preference: ThemePreference) => void;
   setMaterialMarkup: (value: number) => void;
   setLaborMarkup: (value: number) => void;
+  setHourlyRate: (value: number) => void;
   setHapticsEnabled: (value: boolean) => void;
   setHapticIntensity: (value: HapticIntensity) => void;
   setNotificationsEnabled: (value: boolean) => void;
@@ -45,6 +47,7 @@ const DEFAULT_SETTINGS: SettingsState = {
   themePreference: "system",
   materialMarkup: 15,
   laborMarkup: 20,
+  hourlyRate: 85,
   hapticsEnabled: true,
   hapticIntensity: 1,
   notificationsEnabled: true,
@@ -143,6 +146,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     [updateSettings]
   );
 
+  const setHourlyRate = useCallback(
+    (value: number) => {
+      updateSettings({ hourlyRate: Number.isFinite(value) ? Math.max(0, value) : 0 });
+    },
+    [updateSettings]
+  );
+
   const setHapticsEnabled = useCallback(
     (value: boolean) => {
       updateSettings({ hapticsEnabled: value });
@@ -208,6 +218,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setThemePreference,
       setMaterialMarkup,
       setLaborMarkup,
+      setHourlyRate,
       setHapticsEnabled,
       setHapticIntensity,
       setNotificationsEnabled,
@@ -223,6 +234,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setHapticsEnabled,
       setLaborMarkup,
       setMaterialMarkup,
+      setHourlyRate,
       setNotificationsEnabled,
       setThemePreference,
       settings,

--- a/lib/estimateMath.ts
+++ b/lib/estimateMath.ts
@@ -1,0 +1,61 @@
+const CURRENCY_SCALE = 100;
+
+export type EstimateTotalsInput = {
+  materialLineItems: { total: number }[];
+  laborHours?: number;
+  laborRate?: number;
+  taxRate?: number;
+};
+
+export type EstimateTotals = {
+  materialTotal: number;
+  laborHours: number;
+  laborRate: number;
+  laborTotal: number;
+  subtotal: number;
+  taxRate: number;
+  taxTotal: number;
+  grandTotal: number;
+};
+
+function roundCurrency(value: number): number {
+  return Math.round(value * CURRENCY_SCALE) / CURRENCY_SCALE;
+}
+
+function coerceNumber(value: number | undefined | null): number {
+  if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
+    return 0;
+  }
+  return value;
+}
+
+export function calculateEstimateTotals({
+  materialLineItems,
+  laborHours,
+  laborRate,
+  taxRate,
+}: EstimateTotalsInput): EstimateTotals {
+  const materialTotal = roundCurrency(
+    materialLineItems.reduce((acc, item) => acc + coerceNumber(item.total), 0)
+  );
+
+  const safeLaborHours = Math.max(0, coerceNumber(laborHours));
+  const safeLaborRate = Math.max(0, coerceNumber(laborRate));
+  const laborTotal = roundCurrency(safeLaborHours * safeLaborRate);
+
+  const subtotal = roundCurrency(materialTotal + laborTotal);
+  const safeTaxRate = Math.max(0, coerceNumber(taxRate));
+  const taxTotal = roundCurrency(subtotal * (safeTaxRate / 100));
+  const grandTotal = roundCurrency(subtotal + taxTotal);
+
+  return {
+    materialTotal,
+    laborHours: safeLaborHours,
+    laborRate: safeLaborRate,
+    laborTotal,
+    subtotal,
+    taxRate: safeTaxRate,
+    taxTotal,
+    grandTotal,
+  };
+}

--- a/lib/itemCatalog.ts
+++ b/lib/itemCatalog.ts
@@ -1,0 +1,147 @@
+import { v4 as uuidv4 } from "uuid";
+import { openDB, queueChange } from "./sqlite";
+
+export type ItemCatalogRecord = {
+  id: string;
+  user_id: string;
+  description: string;
+  default_quantity: number;
+  unit_price: number;
+  notes: string | null;
+  version: number;
+  updated_at: string;
+  deleted_at: string | null;
+};
+
+export async function listItemCatalog(userId: string): Promise<ItemCatalogRecord[]> {
+  const db = await openDB();
+  const rows = await db.getAllAsync<ItemCatalogRecord>(
+    `SELECT id, user_id, description, default_quantity, unit_price, notes, version, updated_at, deleted_at
+       FROM item_catalog
+       WHERE deleted_at IS NULL AND user_id = ?
+       ORDER BY description COLLATE NOCASE ASC`,
+    [userId]
+  );
+  return rows;
+}
+
+export type UpsertItemCatalogInput = {
+  id?: string | null;
+  userId: string;
+  description: string;
+  unitPrice: number;
+  defaultQuantity?: number;
+  notes?: string | null;
+};
+
+export async function upsertItemCatalog(input: UpsertItemCatalogInput): Promise<ItemCatalogRecord> {
+  const db = await openDB();
+  const now = new Date().toISOString();
+  const normalizedQuantity = Math.max(1, Math.round(input.defaultQuantity ?? 1));
+  const normalizedPrice = Math.max(0, Math.round(input.unitPrice * 100) / 100);
+  const normalizedDescription = input.description.trim();
+  const normalizedNotes = input.notes?.trim() || null;
+
+  if (!normalizedDescription) {
+    throw new Error("Description is required to save an item template.");
+  }
+
+  if (input.id) {
+    const rows = await db.getAllAsync<ItemCatalogRecord>(
+      `SELECT id, user_id, description, default_quantity, unit_price, notes, version, updated_at, deleted_at
+         FROM item_catalog
+         WHERE id = ? LIMIT 1`,
+      [input.id]
+    );
+    const existing = rows[0];
+    const nextVersion = (existing?.version ?? 1) + 1;
+    const record: ItemCatalogRecord = {
+      id: input.id,
+      user_id: existing?.user_id ?? input.userId,
+      description: normalizedDescription,
+      default_quantity: normalizedQuantity,
+      unit_price: normalizedPrice,
+      notes: normalizedNotes,
+      version: nextVersion,
+      updated_at: now,
+      deleted_at: null,
+    };
+
+    await db.runAsync(
+      `UPDATE item_catalog
+         SET description = ?, default_quantity = ?, unit_price = ?, notes = ?, version = ?, updated_at = ?, deleted_at = NULL
+         WHERE id = ?`,
+      [
+        record.description,
+        record.default_quantity,
+        record.unit_price,
+        record.notes,
+        record.version,
+        record.updated_at,
+        record.id,
+      ]
+    );
+
+    await queueChange("item_catalog", "update", record);
+    return record;
+  }
+
+  const record: ItemCatalogRecord = {
+    id: uuidv4(),
+    user_id: input.userId,
+    description: normalizedDescription,
+    default_quantity: normalizedQuantity,
+    unit_price: normalizedPrice,
+    notes: normalizedNotes,
+    version: 1,
+    updated_at: now,
+    deleted_at: null,
+  };
+
+  await db.runAsync(
+    `INSERT INTO item_catalog (id, user_id, description, default_quantity, unit_price, notes, version, updated_at, deleted_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+    [
+      record.id,
+      record.user_id,
+      record.description,
+      record.default_quantity,
+      record.unit_price,
+      record.notes,
+      record.version,
+      record.updated_at,
+    ]
+  );
+
+  await queueChange("item_catalog", "insert", record);
+  return record;
+}
+
+export async function softDeleteItemCatalog(id: string): Promise<void> {
+  const db = await openDB();
+  const now = new Date().toISOString();
+  const rows = await db.getAllAsync<ItemCatalogRecord>(
+    `SELECT id, version FROM item_catalog WHERE id = ? LIMIT 1`,
+    [id]
+  );
+  const existing = rows[0];
+  if (!existing) {
+    return;
+  }
+
+  const record: ItemCatalogRecord = {
+    ...existing,
+    deleted_at: now,
+    updated_at: now,
+    version: (existing.version ?? 1) + 1,
+  };
+
+  await db.runAsync(
+    `UPDATE item_catalog
+       SET deleted_at = ?, updated_at = ?, version = ?
+       WHERE id = ?`,
+    [record.deleted_at, record.updated_at, record.version, record.id]
+  );
+
+  await queueChange("item_catalog", "update", record);
+}

--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from "uuid";
 
 export type Change = {
   id: number;
-  table_name: "customers" | "estimates" | "estimate_items" | "photos";
+  table_name: "customers" | "estimates" | "estimate_items" | "photos" | "item_catalog";
   op: "insert" | "update" | "delete";
   payload: string; // JSON string
   created_at: string;
@@ -68,6 +68,13 @@ export async function initLocalDB(): Promise<void> {
       customer_id TEXT NOT NULL,
       date TEXT DEFAULT (datetime('now')),
       total REAL DEFAULT 0,
+      material_total REAL DEFAULT 0,
+      labor_hours REAL DEFAULT 0,
+      labor_rate REAL DEFAULT 0,
+      labor_total REAL DEFAULT 0,
+      subtotal REAL DEFAULT 0,
+      tax_rate REAL DEFAULT 0,
+      tax_total REAL DEFAULT 0,
       notes TEXT,
       status TEXT DEFAULT 'draft',
       version INTEGER DEFAULT 1,
@@ -85,6 +92,41 @@ export async function initLocalDB(): Promise<void> {
       "ALTER TABLE estimates ADD COLUMN status TEXT DEFAULT 'draft'"
     );
   }
+  if (!estimateColumns.some((column) => column.name === "material_total")) {
+    await db.execAsync(
+      "ALTER TABLE estimates ADD COLUMN material_total REAL DEFAULT 0"
+    );
+  }
+  if (!estimateColumns.some((column) => column.name === "labor_hours")) {
+    await db.execAsync(
+      "ALTER TABLE estimates ADD COLUMN labor_hours REAL DEFAULT 0"
+    );
+  }
+  if (!estimateColumns.some((column) => column.name === "labor_rate")) {
+    await db.execAsync(
+      "ALTER TABLE estimates ADD COLUMN labor_rate REAL DEFAULT 0"
+    );
+  }
+  if (!estimateColumns.some((column) => column.name === "labor_total")) {
+    await db.execAsync(
+      "ALTER TABLE estimates ADD COLUMN labor_total REAL DEFAULT 0"
+    );
+  }
+  if (!estimateColumns.some((column) => column.name === "subtotal")) {
+    await db.execAsync(
+      "ALTER TABLE estimates ADD COLUMN subtotal REAL DEFAULT 0"
+    );
+  }
+  if (!estimateColumns.some((column) => column.name === "tax_rate")) {
+    await db.execAsync(
+      "ALTER TABLE estimates ADD COLUMN tax_rate REAL DEFAULT 0"
+    );
+  }
+  if (!estimateColumns.some((column) => column.name === "tax_total")) {
+    await db.execAsync(
+      "ALTER TABLE estimates ADD COLUMN tax_total REAL DEFAULT 0"
+    );
+  }
 
   // Estimate Items
   await db.execAsync(`
@@ -95,12 +137,22 @@ export async function initLocalDB(): Promise<void> {
       quantity INTEGER NOT NULL,
       unit_price REAL NOT NULL,
       total REAL NOT NULL,
+      catalog_item_id TEXT,
       version INTEGER DEFAULT 1,
       updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
       deleted_at TEXT,
       FOREIGN KEY (estimate_id) REFERENCES estimates(id)
     );
   `);
+
+  const estimateItemColumns = await db.getAllAsync<{ name: string }>(
+    "PRAGMA table_info(estimate_items)"
+  );
+  if (!estimateItemColumns.some((column) => column.name === "catalog_item_id")) {
+    await db.execAsync(
+      "ALTER TABLE estimate_items ADD COLUMN catalog_item_id TEXT"
+    );
+  }
 
   // Photos
   await db.execAsync(`
@@ -114,6 +166,20 @@ export async function initLocalDB(): Promise<void> {
       updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
       deleted_at TEXT,
       FOREIGN KEY (estimate_id) REFERENCES estimates(id)
+    );
+  `);
+
+  await db.execAsync(`
+    CREATE TABLE IF NOT EXISTS item_catalog (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      description TEXT NOT NULL,
+      default_quantity INTEGER DEFAULT 1,
+      unit_price REAL NOT NULL,
+      notes TEXT,
+      version INTEGER DEFAULT 1,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      deleted_at TEXT
     );
   `);
 

--- a/lib/sync.ts
+++ b/lib/sync.ts
@@ -47,7 +47,11 @@ export async function runSync() {
   console.log(`📋 Found ${changes.length} queued change(s)`);
 
   for (const change of changes) {
-    if (["customers", "estimates", "estimate_items", "photos"].includes(change.table_name)) {
+    if (
+      ["customers", "estimates", "estimate_items", "photos", "item_catalog"].includes(
+        change.table_name
+      )
+    ) {
       await processChange(change);
     } else {
       console.warn("⚠️ Skipping unknown table:", change.table_name);

--- a/supabase/migrations/20250213120000_extend_estimate_totals.sql
+++ b/supabase/migrations/20250213120000_extend_estimate_totals.sql
@@ -1,0 +1,92 @@
+-- Add material/labor/tax tracking and item catalog support
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'estimates' AND column_name = 'material_total'
+  ) THEN
+    ALTER TABLE public.estimates
+      ADD COLUMN material_total numeric DEFAULT 0;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'estimates' AND column_name = 'labor_hours'
+  ) THEN
+    ALTER TABLE public.estimates
+      ADD COLUMN labor_hours numeric DEFAULT 0;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'estimates' AND column_name = 'labor_rate'
+  ) THEN
+    ALTER TABLE public.estimates
+      ADD COLUMN labor_rate numeric DEFAULT 0;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'estimates' AND column_name = 'labor_total'
+  ) THEN
+    ALTER TABLE public.estimates
+      ADD COLUMN labor_total numeric DEFAULT 0;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'estimates' AND column_name = 'subtotal'
+  ) THEN
+    ALTER TABLE public.estimates
+      ADD COLUMN subtotal numeric DEFAULT 0;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'estimates' AND column_name = 'tax_rate'
+  ) THEN
+    ALTER TABLE public.estimates
+      ADD COLUMN tax_rate numeric DEFAULT 0;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'estimates' AND column_name = 'tax_total'
+  ) THEN
+    ALTER TABLE public.estimates
+      ADD COLUMN tax_total numeric DEFAULT 0;
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'estimate_items' AND column_name = 'catalog_item_id'
+  ) THEN
+    ALTER TABLE public.estimate_items
+      ADD COLUMN catalog_item_id uuid;
+  END IF;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS public.item_catalog (
+  id uuid PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  description text NOT NULL,
+  default_quantity integer DEFAULT 1,
+  unit_price numeric NOT NULL DEFAULT 0,
+  notes text,
+  version integer DEFAULT 1,
+  updated_at timestamptz DEFAULT timezone('utc', now()),
+  deleted_at timestamptz
+);
+
+ALTER TABLE public.item_catalog
+  ALTER COLUMN version SET DEFAULT 1,
+  ALTER COLUMN updated_at SET DEFAULT timezone('utc', now());
+
+CREATE INDEX IF NOT EXISTS item_catalog_user_idx
+  ON public.item_catalog(user_id)
+  WHERE deleted_at IS NULL;


### PR DESCRIPTION
## Summary
* Added support for storing a default hourly labor rate in the settings context and UI so contractors can manage labor pricing centrally.
* Expanded the estimate item form to integrate a reusable item catalog (with picker and “save for future use” toggle) powered by new SQLite helpers and a Supabase migration.
* Reworked new/edit estimate flows to capture labor hours, hourly rate, tax, and material totals using a shared calculator, persisting the new fields, updating the PDF summary, and exposing the labor/tax breakdown while keeping customer-facing details aggregated.
* Hardened the estimate item modal with a keyboard-aware overlay so contractors can fill out line items without the form dismissing unexpectedly.

## Testing
* ✅ `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68da8df4d36083238bfcb95e4649eb15