### PR TITLE
Preserve offline data during bootstrap and stabilize item modal

### DIFF
--- a/app/(tabs)/estimates/new.tsx
+++ b/app/(tabs)/estimates/new.tsx
@@ -7,11 +7,11 @@ import {
   KeyboardAvoidingView,
   Modal,
   Platform,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
   TextInput,
-  TouchableWithoutFeedback,
   View,
 } from "react-native";
 import { Picker } from "@react-native-picker/picker";
@@ -72,6 +72,7 @@ const itemModalStyles = StyleSheet.create({
     backgroundColor: "#fff",
     borderRadius: 12,
     padding: 20,
+    zIndex: 1,
   },
 });
 
@@ -581,33 +582,44 @@ export default function NewEstimateScreen() {
           keyboardVerticalOffset={Platform.OS === "ios" ? 64 : 0}
           style={{ flex: 1 }}
         >
-          <TouchableWithoutFeedback onPress={closeItemModal} accessible={false}>
-            <View style={itemModalStyles.overlay}>
-              <TouchableWithoutFeedback onPress={() => {}} accessible={false}>
-                <View style={itemModalStyles.card}>
-                  <Text style={{ fontSize: 18, fontWeight: "600", marginBottom: 12 }}>
-                    {editingItem ? "Edit Item" : "Add Item"}
-                  </Text>
-                  <EstimateItemForm
-                    initialValue={
-                      editingItem
-                        ? {
-                            description: editingItem.description,
-                            quantity: editingItem.quantity,
-                            unit_price: editingItem.unit_price,
-                          }
-                        : undefined
-                    }
-                    initialTemplateId={editingItem?.catalog_item_id ?? null}
-                    templates={savedItemTemplates}
-                    onSubmit={handleSubmitItem}
-                    onCancel={closeItemModal}
-                    submitLabel={editingItem ? "Update Item" : "Add Item"}
-                  />
-                </View>
-              </TouchableWithoutFeedback>
+          <View style={itemModalStyles.overlay}>
+            <Pressable
+              accessibilityLabel="Close item editor"
+              accessibilityRole="button"
+              onPress={closeItemModal}
+              style={({ pressed }) => [
+                {
+                  position: "absolute",
+                  top: 0,
+                  right: 0,
+                  bottom: 0,
+                  left: 0,
+                },
+                pressed ? { opacity: 0.85 } : null,
+              ]}
+            />
+            <View style={itemModalStyles.card}>
+              <Text style={{ fontSize: 18, fontWeight: "600", marginBottom: 12 }}>
+                {editingItem ? "Edit Item" : "Add Item"}
+              </Text>
+              <EstimateItemForm
+                initialValue={
+                  editingItem
+                    ? {
+                        description: editingItem.description,
+                        quantity: editingItem.quantity,
+                        unit_price: editingItem.unit_price,
+                      }
+                    : undefined
+                }
+                initialTemplateId={editingItem?.catalog_item_id ?? null}
+                templates={savedItemTemplates}
+                onSubmit={handleSubmitItem}
+                onCancel={closeItemModal}
+                submitLabel={editingItem ? "Update Item" : "Add Item"}
+              />
             </View>
-          </TouchableWithoutFeedback>
+          </View>
         </KeyboardAvoidingView>
       </Modal>
     </ScrollView>

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -95,12 +95,6 @@ export async function bootstrapUserData(userId: string) {
 
   const db = await openDB();
 
-  await db.runAsync("DELETE FROM sync_queue");
-  await db.runAsync("DELETE FROM photos");
-  await db.runAsync("DELETE FROM estimate_items");
-  await db.runAsync("DELETE FROM estimates");
-  await db.runAsync("DELETE FROM customers");
-
   await ensurePhotoDirectory();
   const expectedLocalPaths = new Set<string>();
   const { data: sessionData, error: sessionError } =
@@ -209,6 +203,15 @@ export async function bootstrapUserData(userId: string) {
         photo.deleted_at,
       ]
     );
+  }
+
+  const localPhotoRows = await db.getAllAsync<{ local_uri: string | null }>(
+    "SELECT local_uri FROM photos WHERE local_uri IS NOT NULL"
+  );
+  for (const { local_uri } of localPhotoRows) {
+    if (local_uri) {
+      expectedLocalPaths.add(local_uri);
+    }
   }
 
   if (FileSystem.documentDirectory) {


### PR DESCRIPTION
## Summary
- keep locally queued customer and estimate data when bootstrapping by removing destructive deletes and preserving photo files
- update the estimate item modal overlay to use a non-interfering pressable backdrop so typing no longer closes the form

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68daa284cb648323922696d66be3e91a