### PR TITLE
Fix JSX structure for tax rate section in new estimate screen

### DIFF
--- a/app/(tabs)/estimates/new.tsx
+++ b/app/(tabs)/estimates/new.tsx
@@ -521,8 +521,6 @@ export default function NewEstimateScreen() {
       </View>
 
       <View style={{ gap: 6 }}>
-
-      <View style={{ gap: 6 }}>
         <Text style={{ fontWeight: "600" }}>Tax rate</Text>
         <View style={{ flexDirection: "row", alignItems: "center" }}>
           <TextInput
@@ -537,7 +535,6 @@ export default function NewEstimateScreen() {
       </View>
 
       <View style={{ gap: 6 }}>
-
         <Text style={{ fontWeight: "600" }}>Estimate summary</Text>
         <View style={{ gap: 4 }}>
           <Text>Materials: {formatCurrency(totals.materialTotal)}</Text>


### PR DESCRIPTION
## Summary
- remove the duplicate wrapper view that left the tax rate JSX unterminated
- ensure the estimate summary section remains directly after the tax rate inputs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dacc3afc9083238f7fafcf656e1e8f