### PR TITLE
Refactor estimate item editor to full screen

### DIFF
--- a/app/(tabs)/estimates/_layout.tsx
+++ b/app/(tabs)/estimates/_layout.tsx
@@ -1,17 +1,21 @@
 import { Stack } from "expo-router";
+import { ItemEditorProvider } from "../../../context/ItemEditorContext";
 
 export default function EstimatesLayout() {
   return (
-    <Stack>
-      <Stack.Screen name="index" options={{ headerShown: false }} />
-      <Stack.Screen
-        name="new"
-        options={{ title: "New Estimate", presentation: "modal" }}
-      />
-      <Stack.Screen
-        name="[id]"
-        options={{ title: "Edit Estimate", presentation: "modal" }}
-      />
-    </Stack>
+    <ItemEditorProvider>
+      <Stack>
+        <Stack.Screen name="index" options={{ headerShown: false }} />
+        <Stack.Screen
+          name="new"
+          options={{ title: "New Estimate", presentation: "modal" }}
+        />
+        <Stack.Screen
+          name="[id]"
+          options={{ title: "Edit Estimate", presentation: "modal" }}
+        />
+        <Stack.Screen name="item-editor" options={{ title: "Item" }} />
+      </Stack>
+    </ItemEditorProvider>
   );
 }

--- a/app/(tabs)/estimates/item-editor.tsx
+++ b/app/(tabs)/estimates/item-editor.tsx
@@ -1,0 +1,73 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import { useNavigation, useRouter } from "expo-router";
+import { ScrollView, Text, View } from "react-native";
+import EstimateItemForm from "../../../components/EstimateItemForm";
+import { useItemEditor } from "../../../context/ItemEditorContext";
+
+export default function EstimateItemEditorScreen() {
+  const router = useRouter();
+  const navigation = useNavigation();
+  const { config, closeEditor } = useItemEditor();
+  const hasNavigatedAway = useRef(false);
+
+  useEffect(() => {
+    if (config?.title) {
+      navigation.setOptions({ title: config.title });
+    }
+  }, [config?.title, navigation]);
+
+  useEffect(() => {
+    if (!config && !hasNavigatedAway.current) {
+      hasNavigatedAway.current = true;
+      router.back();
+    }
+  }, [config, router]);
+
+  const handleSubmit = useCallback(
+    async (payload: Parameters<NonNullable<typeof config>["onSubmit"]>[0]) => {
+      if (!config) {
+        return;
+      }
+      await config.onSubmit(payload);
+      closeEditor();
+      if (!hasNavigatedAway.current) {
+        hasNavigatedAway.current = true;
+        router.back();
+      }
+    },
+    [closeEditor, config, router],
+  );
+
+  const handleCancel = useCallback(() => {
+    if (!config) {
+      return;
+    }
+    config.onCancel?.();
+    closeEditor();
+    if (!hasNavigatedAway.current) {
+      hasNavigatedAway.current = true;
+      router.back();
+    }
+  }, [closeEditor, config, router]);
+
+  if (!config) {
+    return <View style={{ flex: 1, backgroundColor: "#fff" }} />;
+  }
+
+  return (
+    <ScrollView
+      contentContainerStyle={{ padding: 16, gap: 16 }}
+      style={{ flex: 1, backgroundColor: "#fff" }}
+    >
+      <Text style={{ fontSize: 20, fontWeight: "600" }}>{config.title}</Text>
+      <EstimateItemForm
+        initialValue={config.initialValue}
+        initialTemplateId={config.initialTemplateId ?? null}
+        templates={config.templates}
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+        submitLabel={config.submitLabel}
+      />
+    </ScrollView>
+  );
+}

--- a/context/ItemEditorContext.tsx
+++ b/context/ItemEditorContext.tsx
@@ -1,0 +1,67 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from "react";
+import type {
+  EstimateItemFormSubmit,
+  EstimateItemTemplate,
+} from "../components/EstimateItemForm";
+
+export type ItemEditorConfig = {
+  title: string;
+  submitLabel?: string;
+  initialValue?: {
+    description: string;
+    quantity: number;
+    unit_price: number;
+  };
+  initialTemplateId?: string | null;
+  templates?: EstimateItemTemplate[];
+  onSubmit: (payload: EstimateItemFormSubmit) => Promise<void> | void;
+  onCancel?: () => void;
+};
+
+export type ItemEditorContextValue = {
+  config: ItemEditorConfig | null;
+  openEditor: (config: ItemEditorConfig) => void;
+  closeEditor: () => void;
+};
+
+const ItemEditorContext = createContext<ItemEditorContextValue | undefined>(
+  undefined,
+);
+
+export function ItemEditorProvider({ children }: PropsWithChildren) {
+  const [config, setConfig] = useState<ItemEditorConfig | null>(null);
+
+  const openEditor = useCallback((nextConfig: ItemEditorConfig) => {
+    setConfig(nextConfig);
+  }, []);
+
+  const closeEditor = useCallback(() => {
+    setConfig(null);
+  }, []);
+
+  const value = useMemo<ItemEditorContextValue>(
+    () => ({ config, openEditor, closeEditor }),
+    [closeEditor, config, openEditor],
+  );
+
+  return (
+    <ItemEditorContext.Provider value={value}>
+      {children}
+    </ItemEditorContext.Provider>
+  );
+}
+
+export function useItemEditor(): ItemEditorContextValue {
+  const context = useContext(ItemEditorContext);
+  if (!context) {
+    throw new Error("useItemEditor must be used within an ItemEditorProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add an item editor context to share configuration between estimate screens
- create a dedicated item-editor route and remove the modal-based workflow
- update new and existing estimate flows to navigate to the full-screen item editor

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68dad328430483238808bcccf82e8993