### PR TITLE
Add default tax rate setting and improve estimate tax handling

### DIFF
--- a/app/(tabs)/estimates/new.tsx
+++ b/app/(tabs)/estimates/new.tsx
@@ -23,6 +23,7 @@ import {
   type ItemCatalogRecord,
 } from "../../../lib/itemCatalog";
 import { calculateEstimateTotals } from "../../../lib/estimateMath";
+import { formatPercentageInput } from "../../../lib/numberFormat";
 
 type EstimateItemRecord = {
   id: string;
@@ -67,7 +68,7 @@ export default function NewEstimateScreen() {
   const [saving, setSaving] = useState(false);
   const [laborHoursText, setLaborHoursText] = useState("0");
   const [hourlyRateText, setHourlyRateText] = useState(settings.hourlyRate.toFixed(2));
-  const [taxRateText, setTaxRateText] = useState("0");
+  const [taxRateText, setTaxRateText] = useState(() => formatPercentageInput(settings.taxRate));
   const [savedItems, setSavedItems] = useState<ItemCatalogRecord[]>([]);
 
   const userId = user?.id ?? session?.user?.id ?? null;
@@ -75,6 +76,10 @@ export default function NewEstimateScreen() {
   useEffect(() => {
     setHourlyRateText(settings.hourlyRate.toFixed(2));
   }, [settings.hourlyRate]);
+
+  useEffect(() => {
+    setTaxRateText(formatPercentageInput(settings.taxRate));
+  }, [settings.taxRate]);
 
   const loadSavedItems = useCallback(async () => {
     if (!userId) {
@@ -112,9 +117,9 @@ export default function NewEstimateScreen() {
   }, [hourlyRateText, parseNumericInput, settings.hourlyRate]);
 
   const taxRate = useMemo(() => {
-    const parsed = parseNumericInput(taxRateText, 0);
+    const parsed = parseNumericInput(taxRateText, settings.taxRate);
     return Math.max(0, Math.round(parsed * 100) / 100);
-  }, [parseNumericInput, taxRateText]);
+  }, [parseNumericInput, settings.taxRate, taxRateText]);
 
   const totals = useMemo(
     () =>
@@ -497,20 +502,6 @@ export default function NewEstimateScreen() {
         </View>
       </View>
 
-
-      <View style={{ gap: 6 }}>
-        <Text style={{ fontWeight: "600" }}>Tax rate</Text>
-        <View style={{ flexDirection: "row", alignItems: "center" }}>
-          <TextInput
-            placeholder="0"
-            value={taxRateText}
-            onChangeText={setTaxRateText}
-            keyboardType="decimal-pad"
-            style={{ flex: 1, borderWidth: 1, borderRadius: 8, padding: 10 }}
-          />
-          <Text style={{ fontWeight: "600", marginLeft: 8 }}>%</Text>
-        </View>
-      </View>
 
       <View style={{ gap: 6 }}>
         <Text style={{ fontWeight: "600" }}>Tax rate</Text>

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -31,6 +31,7 @@ export default function Settings() {
     setMaterialMarkup,
     setLaborMarkup,
     setHourlyRate,
+    setTaxRate,
     setHapticsEnabled,
     setHapticIntensity,
     setNotificationsEnabled,
@@ -42,6 +43,9 @@ export default function Settings() {
   const [materialMarkupInput, setMaterialMarkupInput] = useState(settings.materialMarkup.toString());
   const [laborMarkupInput, setLaborMarkupInput] = useState(settings.laborMarkup.toString());
   const [hourlyRateInput, setHourlyRateInput] = useState(settings.hourlyRate.toFixed(2));
+  const [taxRateInput, setTaxRateInput] = useState(() =>
+    settings.taxRate % 1 === 0 ? settings.taxRate.toFixed(0) : settings.taxRate.toString()
+  );
 
   useEffect(() => {
     setMaterialMarkupInput(settings.materialMarkup.toString());
@@ -54,6 +58,10 @@ export default function Settings() {
   useEffect(() => {
     setHourlyRateInput(settings.hourlyRate.toFixed(2));
   }, [settings.hourlyRate]);
+
+  useEffect(() => {
+    setTaxRateInput(settings.taxRate % 1 === 0 ? settings.taxRate.toFixed(0) : settings.taxRate.toString());
+  }, [settings.taxRate]);
 
   const colors = useMemo(() => {
     const isDark = resolvedTheme === "dark";
@@ -308,6 +316,31 @@ export default function Settings() {
                   onChangeText={setLaborMarkupInput}
                   onBlur={() => handleUpdateMarkup(laborMarkupInput, setLaborMarkup)}
                   keyboardType="numeric"
+                  returnKeyType="done"
+                  style={themedStyles.textField}
+                  placeholder="0"
+                  placeholderTextColor={colors.secondaryText}
+                />
+              </View>
+              <Text style={themedStyles.percentSuffix}>%</Text>
+            </View>
+          </View>
+        </View>
+
+        <View style={themedStyles.section}>
+          <Text style={themedStyles.sectionHeader}>Tax defaults</Text>
+          <Text style={themedStyles.sectionDescription}>
+            Set the default sales tax rate that will be applied to new estimates. You can still adjust it per project.
+          </Text>
+          <View>
+            <Text style={themedStyles.rowLabel}>Tax rate</Text>
+            <View style={styles.inputRow}>
+              <View style={themedStyles.textFieldContainer}>
+                <TextInput
+                  value={taxRateInput}
+                  onChangeText={setTaxRateInput}
+                  onBlur={() => handleUpdateMarkup(taxRateInput, setTaxRate)}
+                  keyboardType="decimal-pad"
                   returnKeyType="done"
                   style={themedStyles.textField}
                   placeholder="0"

--- a/context/SettingsContext.tsx
+++ b/context/SettingsContext.tsx
@@ -21,6 +21,7 @@ export interface SettingsState {
   materialMarkup: number;
   laborMarkup: number;
   hourlyRate: number;
+  taxRate: number;
   hapticsEnabled: boolean;
   hapticIntensity: HapticIntensity;
   notificationsEnabled: boolean;
@@ -35,6 +36,7 @@ interface SettingsContextValue {
   setMaterialMarkup: (value: number) => void;
   setLaborMarkup: (value: number) => void;
   setHourlyRate: (value: number) => void;
+  setTaxRate: (value: number) => void;
   setHapticsEnabled: (value: boolean) => void;
   setHapticIntensity: (value: HapticIntensity) => void;
   setNotificationsEnabled: (value: boolean) => void;
@@ -48,6 +50,7 @@ const DEFAULT_SETTINGS: SettingsState = {
   materialMarkup: 15,
   laborMarkup: 20,
   hourlyRate: 85,
+  taxRate: 8,
   hapticsEnabled: true,
   hapticIntensity: 1,
   notificationsEnabled: true,
@@ -153,6 +156,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     [updateSettings]
   );
 
+  const setTaxRate = useCallback(
+    (value: number) => {
+      updateSettings({ taxRate: Number.isFinite(value) ? Math.max(0, value) : 0 });
+    },
+    [updateSettings]
+  );
+
   const setHapticsEnabled = useCallback(
     (value: boolean) => {
       updateSettings({ hapticsEnabled: value });
@@ -219,6 +229,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setMaterialMarkup,
       setLaborMarkup,
       setHourlyRate,
+      setTaxRate,
       setHapticsEnabled,
       setHapticIntensity,
       setNotificationsEnabled,
@@ -235,6 +246,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setLaborMarkup,
       setMaterialMarkup,
       setHourlyRate,
+      setTaxRate,
       setNotificationsEnabled,
       setThemePreference,
       settings,

--- a/lib/numberFormat.ts
+++ b/lib/numberFormat.ts
@@ -1,0 +1,11 @@
+export function formatPercentageInput(value: number): string {
+  if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
+    return "0";
+  }
+
+  const normalized = Math.max(0, Math.round(value * 100) / 100);
+  if (normalized % 1 === 0) {
+    return normalized.toFixed(0);
+  }
+  return normalized.toString();
+}


### PR DESCRIPTION
## Summary
- add a persisted taxRate setting alongside its context setter
- surface the tax rate input on the settings screen so new estimates inherit it automatically
- reuse a shared percentage formatter and remove the duplicate tax input on the new estimate form

## Testing
- npm test -- --runInBand *(fails: Cannot find module 'expo-asset' from 'node_modules/expo-sqlite/build/hooks.js')*

------
https://chatgpt.com/codex/tasks/task_e_68dbc5e3afa88323ad7fe05c384247e1