### PR TITLE
Handle missing photo directory on web bootstrap

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -165,27 +165,29 @@ export async function bootstrapUserData(userId: string) {
     let localUri: string | null = null;
     if (photo.uri) {
       const derivedPath = deriveLocalPhotoUri(photo.id, photo.uri);
-      if (!photo.deleted_at) {
-        expectedLocalPaths.add(derivedPath);
-        try {
-          const info = await FileSystem.getInfoAsync(derivedPath);
-          if (info.exists) {
-            localUri = derivedPath;
-          } else if (canDownloadPhotos) {
-            const downloaded = await downloadPhotoBinary(
-              photo.uri,
-              derivedPath,
-              bootstrapAccessToken
-            );
-            if (downloaded) {
+      if (derivedPath) {
+        if (!photo.deleted_at) {
+          expectedLocalPaths.add(derivedPath);
+          try {
+            const info = await FileSystem.getInfoAsync(derivedPath);
+            if (info.exists) {
               localUri = derivedPath;
+            } else if (canDownloadPhotos) {
+              const downloaded = await downloadPhotoBinary(
+                photo.uri,
+                derivedPath,
+                bootstrapAccessToken
+              );
+              if (downloaded) {
+                localUri = derivedPath;
+              }
             }
+          } catch (error) {
+            console.warn(`Failed to prepare local copy for photo ${photo.id}`, error);
           }
-        } catch (error) {
-          console.warn(`Failed to prepare local copy for photo ${photo.id}`, error);
+        } else {
+          await deleteLocalPhoto(derivedPath);
         }
-      } else {
-        await deleteLocalPhoto(derivedPath);
       }
     }
 


### PR DESCRIPTION
## Summary
- treat the Expo document directory as optional so photo sync helpers skip when it is not available (e.g. on web)
- guard bootstrap photo hydration logic against missing local storage paths so downloads are optional instead of fatal

## Testing
- npm test -- --watch=false *(fails: expo-sqlite is unavailable in the Jest environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd0641c6c83238d84489c1e778616