### PR TITLE
Fix new estimate item persistence and add regression tests

### DIFF
--- a/__mocks__/expo-sqlite.js
+++ b/__mocks__/expo-sqlite.js
@@ -1,0 +1,10 @@
+const mockDb = {
+  execAsync: jest.fn().mockResolvedValue(undefined),
+  runAsync: jest.fn().mockResolvedValue(undefined),
+  getAllAsync: jest.fn().mockResolvedValue([]),
+};
+
+module.exports = {
+  openDatabaseAsync: jest.fn().mockResolvedValue(mockDb),
+  __mockDb: mockDb,
+};

--- a/__tests__/home.test.tsx
+++ b/__tests__/home.test.tsx
@@ -1,10 +1,29 @@
 import React from "react";
 import { render } from "@testing-library/react-native";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+jest.mock("expo-router", () => {
+  const React = require("react");
+  return {
+    useFocusEffect: (effect: () => void) => {
+      React.useEffect(effect, []);
+    },
+  };
+});
+
 import Home from "../app/(tabs)/home";
 
 describe("Home screen", () => {
-  it("renders the welcome message", () => {
-    const { getByText } = render(<Home />);
-    expect(getByText("🏠 Welcome to QuickQuote")).toBeTruthy();
+  it("renders the welcome message", async () => {
+    const { findByText } = render(
+      <SafeAreaProvider
+        initialMetrics={{
+          frame: { x: 0, y: 0, width: 320, height: 640 },
+          insets: { top: 0, left: 0, right: 0, bottom: 0 },
+        }}
+      >
+        <Home />
+      </SafeAreaProvider>,
+    );
+    await expect(findByText("Good to see you")).resolves.toBeTruthy();
   });
 });

--- a/__tests__/newEstimate.test.tsx
+++ b/__tests__/newEstimate.test.tsx
@@ -1,0 +1,191 @@
+import React from "react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native";
+import { Alert } from "react-native";
+
+jest.mock("expo-router", () => {
+  const push = jest.fn();
+  const back = jest.fn();
+  const router = { push, back };
+  return {
+    __esModule: true,
+    router,
+    useRouter: () => router,
+  };
+});
+
+const mockOpenEditor = jest.fn();
+
+const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+
+jest.mock("../context/ItemEditorContext", () => ({
+  useItemEditor: () => ({
+    config: null,
+    openEditor: mockOpenEditor,
+    closeEditor: jest.fn(),
+  }),
+}));
+
+jest.mock("../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "user-123" },
+    session: null,
+  }),
+}));
+
+jest.mock("../context/SettingsContext", () => ({
+  useSettings: () => ({
+    settings: {
+      hourlyRate: 50,
+      taxRate: 8,
+    },
+  }),
+}));
+
+jest.mock("../lib/itemCatalog", () => ({
+  listItemCatalog: jest.fn().mockResolvedValue([]),
+  upsertItemCatalog: jest.fn(),
+}));
+
+jest.mock("../components/CustomerPicker", () => ({
+  __esModule: true,
+  default: ({ onSelect }: { onSelect: (id: string) => void }) => {
+    const React = require("react");
+    React.useEffect(() => {
+      onSelect("customer-1");
+    }, [onSelect]);
+    return null;
+  },
+}));
+
+const mockDbInstance = {
+  getAllAsync: jest.fn().mockResolvedValue([]),
+  runAsync: jest.fn().mockResolvedValue(undefined),
+  execAsync: jest.fn().mockResolvedValue(undefined),
+};
+
+jest.mock("../lib/sqlite", () => ({
+  __esModule: true,
+  openDB: jest.fn().mockResolvedValue(mockDbInstance),
+  queueChange: jest.fn(),
+}));
+
+jest.mock("../lib/sync", () => ({
+  runSync: jest.fn(),
+}));
+
+import NewEstimateScreen from "../app/(tabs)/estimates/new";
+import { openDB, queueChange } from "../lib/sqlite";
+
+function submitConfigItem(index = 0) {
+  const call = mockOpenEditor.mock.calls[index];
+  if (!call) {
+    throw new Error("No item editor config captured");
+  }
+  return call[0];
+}
+
+describe("NewEstimateScreen", () => {
+  beforeEach(() => {
+    mockOpenEditor.mockClear();
+    alertSpy.mockClear();
+    mockDbInstance.runAsync.mockClear();
+    mockDbInstance.execAsync.mockClear();
+    (queueChange as jest.Mock).mockClear();
+    (openDB as jest.Mock).mockResolvedValue(mockDbInstance);
+  });
+
+  it("adds a new line item to the quote when the editor submits", async () => {
+    const { getByText } = render(<NewEstimateScreen />);
+
+    fireEvent.press(getByText("Add Item"));
+
+    expect(mockOpenEditor).toHaveBeenCalledTimes(1);
+
+    const config = submitConfigItem();
+
+    await act(async () => {
+      await config.onSubmit({
+        values: {
+          description: "Demo Item",
+          quantity: 2,
+          unit_price: 25,
+          total: 50,
+        },
+        saveToLibrary: false,
+        templateId: null,
+      });
+    });
+
+    await waitFor(() => {
+      expect(getByText("Demo Item")).toBeTruthy();
+      expect(getByText(/Line Total: \$50.00/)).toBeTruthy();
+    });
+  });
+
+  it("saves the estimate and queues database operations", async () => {
+    const { getByText } = render(<NewEstimateScreen />);
+
+    fireEvent.press(getByText("Add Item"));
+    const config = submitConfigItem();
+
+    await act(async () => {
+      await config.onSubmit({
+        values: {
+          description: "Widget",
+          quantity: 3,
+          unit_price: 40,
+          total: 120,
+        },
+        saveToLibrary: false,
+        templateId: null,
+      });
+    });
+
+    await waitFor(() => {
+      expect(getByText("Widget")).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.press(getByText("Save"));
+    });
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Success",
+        "Estimate created successfully.",
+        expect.any(Array)
+      );
+    });
+
+    expect(mockDbInstance.runAsync).toHaveBeenCalledTimes(2);
+
+    const [estimateInsertArgs, itemInsertArgs] = mockDbInstance.runAsync.mock.calls;
+    const estimateParams = estimateInsertArgs[1];
+    const itemParams = itemInsertArgs[1];
+
+    expect(estimateInsertArgs[0]).toContain("INSERT OR REPLACE INTO estimates");
+    expect(estimateParams[1]).toBe("user-123");
+    expect(estimateParams[2]).toBe("customer-1");
+
+    expect(itemInsertArgs[0]).toContain("INSERT OR REPLACE INTO estimate_items");
+    expect(itemParams[1]).toBe(estimateParams[0]);
+    expect(itemParams[3]).toBe(3);
+    expect(itemParams[4]).toBe(40);
+    expect(itemParams[5]).toBe(120);
+
+    expect((queueChange as jest.Mock).mock.calls).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining([
+          "estimate_items",
+          "insert",
+          expect.objectContaining({ estimate_id: estimateParams[0], total: 120 }),
+        ]),
+        expect.arrayContaining([
+          "estimates",
+          "insert",
+          expect.objectContaining({ id: estimateParams[0], customer_id: "customer-1" }),
+        ]),
+      ])
+    );
+  });
+});

--- a/app/(tabs)/estimates/new.tsx
+++ b/app/(tabs)/estimates/new.tsx
@@ -210,7 +210,17 @@ export default function NewEstimateScreen() {
   const openItemEditorScreen = useCallback(
     (config: ItemEditorConfig) => {
       preserveDraftRef.current = true;
-      openEditor(config);
+      openEditor({
+        ...config,
+        onSubmit: async (payload) => {
+          await config.onSubmit(payload);
+          preserveDraftRef.current = false;
+        },
+        onCancel: () => {
+          config.onCancel?.();
+          preserveDraftRef.current = false;
+        },
+      });
       router.push("/(tabs)/estimates/item-editor");
     },
     [openEditor],

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,6 @@ module.exports = {
   preset: "jest-expo",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   transformIgnorePatterns: [
-    "node_modules/(?!(jest-)?react-native|@react-native|expo(nent)?|@expo|@unimodules|unimodules|@react-native-community|@react-navigation/.*|expo-router)",
+    "node_modules/(?!(jest-)?react-native|@react-native|expo(nent)?|@expo|@unimodules|unimodules|@react-native-community|@react-navigation/.*|expo-router|uuid)",
   ],
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -27,3 +27,28 @@ if (!globalThis.TransformStream) {
   // eslint-disable-next-line no-global-assign
   globalThis.TransformStream = NativeTransformStream as unknown as typeof globalThis.TransformStream;
 }
+
+jest.mock("react-native/Libraries/Components/Touchable/TouchableOpacity", () => {
+  const React = require("react");
+
+  const MockTouchableOpacity = React.forwardRef(
+    (
+      { children, onPress, ...rest }: any,
+      ref: any,
+    ) => {
+      return React.createElement(
+        "RNMockTouchableOpacity",
+        {
+          ...rest,
+          onPress,
+          ref,
+        },
+        children,
+      );
+    },
+  );
+
+  MockTouchableOpacity.displayName = "MockTouchableOpacity";
+
+  return MockTouchableOpacity;
+});


### PR DESCRIPTION
## Summary
- ensure the new estimate screen clears the preserve-draft flag after the item editor submits or cancels so added line items persist reliably
- add focused tests for the new estimate add/save flows alongside supporting jest mocks and home screen harness updates
- stub TouchableOpacity in Jest and allow transforming uuid to keep the suite green with the new coverage

## Testing
- npm test -- --runTestsByPath __tests__/newEstimate.test.tsx
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbd41565d88323923db01c806a6a17