### PR TITLE
Add brand logo presentation across authentication and dashboard

### DIFF
--- a/app/(auth)/forgot-password.tsx
+++ b/app/(auth)/forgot-password.tsx
@@ -11,6 +11,7 @@ import {
   View,
 } from "react-native";
 import { supabase } from "../../lib/supabase";
+import { BrandLogo } from "../../components/BrandLogo";
 
 const RESET_REDIRECT = process.env.EXPO_PUBLIC_SUPABASE_RESET_REDIRECT;
 
@@ -52,6 +53,9 @@ export default function ForgotPasswordScreen() {
       style={styles.container}
     >
       <View style={styles.card}>
+        <View style={styles.logoContainer}>
+          <BrandLogo size={80} />
+        </View>
         <Text style={styles.title}>Reset your password</Text>
         <TextInput
           autoCapitalize="none"
@@ -94,6 +98,10 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 8 },
     shadowRadius: 12,
     elevation: 6,
+  },
+  logoContainer: {
+    alignItems: "center",
+    marginBottom: 4,
   },
   title: {
     fontSize: 24,

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -11,6 +11,7 @@ import {
   View,
 } from "react-native";
 import { supabase } from "../../lib/supabase";
+import { BrandLogo } from "../../components/BrandLogo";
 
 export default function LoginScreen() {
   const [email, setEmail] = useState("");
@@ -49,6 +50,9 @@ export default function LoginScreen() {
       style={styles.container}
     >
       <View style={styles.card}>
+        <View style={styles.logoContainer}>
+          <BrandLogo size={80} />
+        </View>
         <Text style={styles.title}>Welcome back</Text>
         <TextInput
           autoCapitalize="none"
@@ -104,6 +108,10 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 8 },
     shadowRadius: 12,
     elevation: 6,
+  },
+  logoContainer: {
+    alignItems: "center",
+    marginBottom: 4,
   },
   title: {
     fontSize: 24,

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -11,6 +11,7 @@ import {
   View,
 } from "react-native";
 import { supabase } from "../../lib/supabase";
+import { BrandLogo } from "../../components/BrandLogo";
 
 export default function SignupScreen() {
   const [email, setEmail] = useState("");
@@ -59,6 +60,9 @@ export default function SignupScreen() {
       style={styles.container}
     >
       <View style={styles.card}>
+        <View style={styles.logoContainer}>
+          <BrandLogo size={80} />
+        </View>
         <Text style={styles.title}>Create your account</Text>
         <TextInput
           autoCapitalize="none"
@@ -121,6 +125,10 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 8 },
     shadowRadius: 12,
     elevation: 6,
+  },
+  logoContainer: {
+    alignItems: "center",
+    marginBottom: 4,
   },
   title: {
     fontSize: 24,

--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -10,6 +10,7 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { openDB } from "../../lib/sqlite";
+import { BrandLogo } from "../../components/BrandLogo";
 
 type DashboardMetrics = {
   jobsSold: number;
@@ -56,6 +57,16 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 10 },
     elevation: 6,
   },
+  heroCardHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 20,
+    marginBottom: 20,
+  },
+  heroHeaderText: {
+    flex: 1,
+  },
   heroTitle: {
     color: "#FFFFFF",
     fontSize: 28,
@@ -64,7 +75,7 @@ const styles = StyleSheet.create({
   },
   heroSubtitle: {
     color: "rgba(255,255,255,0.72)",
-    marginTop: 10,
+    marginTop: 8,
     fontSize: 16,
     lineHeight: 24,
   },
@@ -409,8 +420,13 @@ export default function Home() {
       }
     >
       <View style={styles.heroCard}>
-        <Text style={styles.heroTitle}>Good to see you</Text>
-        <Text style={styles.heroSubtitle}>{heroSummary}</Text>
+        <View style={styles.heroCardHeader}>
+          <View style={styles.heroHeaderText}>
+            <Text style={styles.heroTitle}>Good to see you</Text>
+            <Text style={styles.heroSubtitle}>{heroSummary}</Text>
+          </View>
+          <BrandLogo size={56} />
+        </View>
         <View style={styles.heroStatRow}>
           <View>
             <Text style={styles.heroStatLabel}>Booked revenue</Text>

--- a/components/BrandLogo.tsx
+++ b/components/BrandLogo.tsx
@@ -1,0 +1,27 @@
+import { Image, ImageStyle, StyleProp } from "react-native";
+
+type BrandLogoProps = {
+  size?: number;
+  style?: StyleProp<ImageStyle>;
+};
+
+export function BrandLogo({ size = 72, style }: BrandLogoProps) {
+  return (
+    <Image
+      accessibilityRole="image"
+      accessibilityLabel="QuickQuote logo"
+      source={require("../assets/icon.png")}
+      style={[
+        {
+          width: size,
+          height: size,
+          borderRadius: size / 5,
+        },
+        style,
+      ]}
+      resizeMode="contain"
+    />
+  );
+}
+
+export default BrandLogo;


### PR DESCRIPTION
## Summary
- add a reusable `BrandLogo` component that sources the new icon asset
- surface the refreshed branding on authentication screens and the dashboard hero
- tweak the home hero layout so the logo sits alongside the greeting copy

## Testing
- npm test -- --runInBand *(fails: `__tests__/newEstimate.test.tsx` exceeded its 5000 ms timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe3c9db788323b5c8acf0920ab5e1