### PR TITLE
Add customer search and stabilize estimate workflow

### DIFF
--- a/app/(tabs)/estimates/[id].tsx
+++ b/app/(tabs)/estimates/[id].tsx
@@ -1523,7 +1523,10 @@ export default function EditEstimateScreen() {
       style={{ flex: 1, backgroundColor: "#fff" }}
     >
       <Text style={{ fontSize: 20, fontWeight: "600" }}>Edit Estimate</Text>
-      <CustomerPicker selectedCustomer={customerId} onSelect={setCustomerId} />
+      <CustomerPicker
+        selectedCustomer={customerId}
+        onSelect={(id) => setCustomerId(id)}
+      />
 
       <View style={{ gap: 6 }}>
         <Text style={{ fontWeight: "600" }}>Date</Text>

--- a/app/(tabs)/estimates/new.tsx
+++ b/app/(tabs)/estimates/new.tsx
@@ -531,7 +531,10 @@ export default function NewEstimateScreen() {
       style={{ flex: 1, backgroundColor: "#fff" }}
     >
       <Text style={{ fontSize: 20, fontWeight: "600" }}>New Estimate</Text>
-      <CustomerPicker selectedCustomer={customerId} onSelect={setCustomerId} />
+      <CustomerPicker
+        selectedCustomer={customerId}
+        onSelect={(id) => setCustomerId(id)}
+      />
 
       <View style={{ gap: 6 }}>
         <Text style={{ fontWeight: "600" }}>Date</Text>

--- a/components/CustomerPicker.tsx
+++ b/components/CustomerPicker.tsx
@@ -1,6 +1,13 @@
 // components/CustomerPicker.tsx
-import React, { useEffect, useState } from "react";
-import { View, Text, ActivityIndicator, Button, Alert } from "react-native";
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  ActivityIndicator,
+  Button,
+  Alert,
+  TextInput,
+} from "react-native";
 import { Picker } from "@react-native-picker/picker";
 import { openDB } from "../lib/sqlite";
 import CustomerForm from "./CustomerForm";
@@ -16,13 +23,14 @@ type Customer = {
 
 type Props = {
   selectedCustomer: string | null;
-  onSelect: (id: string) => void;
+  onSelect: (id: string | null) => void;
 };
 
 export default function CustomerPicker({ selectedCustomer, onSelect }: Props) {
   const [customers, setCustomers] = useState<Customer[]>([]);
   const [loading, setLoading] = useState(true);
   const [addingNew, setAddingNew] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
 
   async function loadCustomers() {
     setLoading(true);
@@ -61,12 +69,57 @@ export default function CustomerPicker({ selectedCustomer, onSelect }: Props) {
               a.name.localeCompare(b.name)
             )
           );
+          setSearchQuery("");
           onSelect(c.id);
         }}
         onCancel={() => setAddingNew(false)}
       />
     );
   }
+
+  const filteredCustomers = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) {
+      return customers;
+    }
+
+    const matches = customers.filter((customer) => {
+      const nameMatch = customer.name.toLowerCase().includes(query);
+      const phoneMatch = customer.phone?.toLowerCase().includes(query);
+      const emailMatch = customer.email?.toLowerCase().includes(query);
+      const addressMatch = customer.address?.toLowerCase().includes(query);
+
+      return Boolean(nameMatch || phoneMatch || emailMatch || addressMatch);
+    });
+
+    if (
+      selectedCustomer &&
+      !matches.some((customer) => customer.id === selectedCustomer)
+    ) {
+      const selected = customers.find(
+        (customer) => customer.id === selectedCustomer,
+      );
+      if (selected) {
+        return [selected, ...matches];
+      }
+    }
+
+    return matches;
+  }, [customers, searchQuery, selectedCustomer]);
+
+  const handleSelect = (value: string | number) => {
+    if (value === "new") {
+      setAddingNew(true);
+      return;
+    }
+
+    if (!value) {
+      onSelect(null);
+      return;
+    }
+
+    onSelect(String(value));
+  };
 
   if (loading) {
     return (
@@ -80,15 +133,28 @@ export default function CustomerPicker({ selectedCustomer, onSelect }: Props) {
   return (
     <View style={{ marginVertical: 10 }}>
       <Text style={{ marginBottom: 6, fontWeight: "600" }}>Select Customer</Text>
+      <TextInput
+        value={searchQuery}
+        onChangeText={setSearchQuery}
+        placeholder="Search by name, phone, email, or address"
+        autoCorrect={false}
+        style={{
+          borderWidth: 1,
+          borderRadius: 8,
+          paddingHorizontal: 10,
+          paddingVertical: 8,
+          marginBottom: 8,
+        }}
+      />
       <Picker
         selectedValue={selectedCustomer ?? ""}
-        onValueChange={(value: string) => {
-          if (value === "new") setAddingNew(true);
-          else onSelect(value);
-        }}
+        onValueChange={handleSelect}
       >
         <Picker.Item label="-- Select --" value="" />
-        {customers.map((c: Customer) => (
+        {filteredCustomers.length === 0 ? (
+          <Picker.Item label="No matching customers" value="" enabled={false} />
+        ) : null}
+        {filteredCustomers.map((c: Customer) => (
           <Picker.Item key={c.id} label={c.name} value={c.id} />
         ))}
         <Picker.Item label="➕ Add New Customer" value="new" />


### PR DESCRIPTION
## Summary
- add search input and filtering to the estimate customer picker while preserving the current selection
- reset the picker search when a customer is created and expose null-safe selection handling
- update estimate create/edit screens to use the refreshed picker contract

## Testing
- npm test -- --runTestsByPath __tests__/newEstimate.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dbeccce1048323af21a4374c3da768