### PR TITLE
Reset item editor draft preservation flag after closing

### DIFF
--- a/app/(tabs)/estimates/[id].tsx
+++ b/app/(tabs)/estimates/[id].tsx
@@ -469,7 +469,23 @@ export default function EditEstimateScreen() {
   const openItemEditorScreen = useCallback(
     (config: ItemEditorConfig) => {
       preserveDraftRef.current = true;
-      openEditor(config);
+      openEditor({
+        ...config,
+        onSubmit: async (payload) => {
+          try {
+            await config.onSubmit(payload);
+          } finally {
+            preserveDraftRef.current = false;
+          }
+        },
+        onCancel: () => {
+          try {
+            config.onCancel?.();
+          } finally {
+            preserveDraftRef.current = false;
+          }
+        },
+      });
       router.push("/(tabs)/estimates/item-editor");
     },
     [openEditor],

--- a/app/(tabs)/estimates/new.tsx
+++ b/app/(tabs)/estimates/new.tsx
@@ -213,12 +213,18 @@ export default function NewEstimateScreen() {
       openEditor({
         ...config,
         onSubmit: async (payload) => {
-          await config.onSubmit(payload);
-          preserveDraftRef.current = false;
+          try {
+            await config.onSubmit(payload);
+          } finally {
+            preserveDraftRef.current = false;
+          }
         },
         onCancel: () => {
-          config.onCancel?.();
-          preserveDraftRef.current = false;
+          try {
+            config.onCancel?.();
+          } finally {
+            preserveDraftRef.current = false;
+          }
         },
       });
       router.push("/(tabs)/estimates/item-editor");


### PR DESCRIPTION
## Summary
- ensure both new and existing estimate screens reset the draft preservation flag when the item editor submits or cancels so drafts can clean up correctly

## Testing
- npm test -- --runTestsByPath __tests__/newEstimate.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dbf29e0a388323a26c38893f90808a