### PR TITLE
Revamp estimate form and onboarding profile

### DIFF
--- a/__tests__/editEstimateItems.test.tsx
+++ b/__tests__/editEstimateItems.test.tsx
@@ -38,7 +38,16 @@ jest.mock("../context/SettingsContext", () => ({
     settings: {
       hourlyRate: 55,
       taxRate: 7.5,
+      companyProfile: {
+        name: "QuickQuote Co.",
+        email: "hello@example.com",
+        phone: "555-111-2222",
+        website: "quickquote.test",
+        address: "123 Main St",
+        logoUri: null,
+      },
     },
+    resolvedTheme: "light",
   }),
 }));
 
@@ -192,6 +201,7 @@ describe("EditEstimateScreen - item editing", () => {
   it("adds a new item to the estimate when the editor submits", async () => {
     const { findByText, getByText } = render(<EditEstimateScreen />);
 
+    await act(async () => {});
     await findByText("Items");
 
     fireEvent.press(getByText("Add Item"));

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -1,10 +1,11 @@
 import { Link, router } from "expo-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Alert,
   KeyboardAvoidingView,
   Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -12,12 +13,30 @@ import {
 } from "react-native";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
+import LogoPicker from "../../components/LogoPicker";
+import { useSettings } from "../../context/SettingsContext";
 
 export default function SignupScreen() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [companyName, setCompanyName] = useState("");
+  const [companyEmail, setCompanyEmail] = useState("");
+  const [companyPhone, setCompanyPhone] = useState("");
+  const [companyWebsite, setCompanyWebsite] = useState("");
+  const [companyAddress, setCompanyAddress] = useState("");
+  const [logoUri, setLogoUri] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const { settings, setCompanyProfile } = useSettings();
+
+  useEffect(() => {
+    setCompanyName(settings.companyProfile.name ?? "");
+    setCompanyEmail(settings.companyProfile.email ?? "");
+    setCompanyPhone(settings.companyProfile.phone ?? "");
+    setCompanyWebsite(settings.companyProfile.website ?? "");
+    setCompanyAddress(settings.companyProfile.address ?? "");
+    setLogoUri(settings.companyProfile.logoUri ?? null);
+  }, [settings.companyProfile]);
 
   const handleSignup = async () => {
     if (!email || !password || !confirmPassword) {
@@ -41,6 +60,15 @@ export default function SignupScreen() {
         throw error;
       }
 
+      setCompanyProfile({
+        name: companyName.trim(),
+        email: companyEmail.trim(),
+        phone: companyPhone.trim(),
+        website: companyWebsite.trim(),
+        address: companyAddress.trim(),
+        logoUri,
+      });
+
       Alert.alert(
         "Check your inbox",
         "We sent a confirmation email. Confirm your address and then sign in."
@@ -59,51 +87,108 @@ export default function SignupScreen() {
       behavior={Platform.select({ ios: "padding", android: undefined })}
       style={styles.container}
     >
-      <View style={styles.card}>
-        <View style={styles.logoContainer}>
-          <BrandLogo size={80} />
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+        <View style={styles.card}>
+          <View style={styles.logoContainer}>
+            <BrandLogo size={80} />
+          </View>
+          <Text style={styles.title}>Create your account</Text>
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Account details</Text>
+            <Text style={styles.sectionSubtitle}>
+              Sign in with your work email so we can keep your estimates in sync.
+            </Text>
+            <TextInput
+              autoCapitalize="none"
+              autoComplete="email"
+              autoCorrect={false}
+              keyboardType="email-address"
+              placeholder="Email"
+              placeholderTextColor="#888"
+              style={styles.input}
+              value={email}
+              onChangeText={setEmail}
+            />
+            <TextInput
+              autoCapitalize="none"
+              autoComplete="password"
+              placeholder="Password"
+              placeholderTextColor="#888"
+              secureTextEntry
+              style={styles.input}
+              value={password}
+              onChangeText={setPassword}
+            />
+            <TextInput
+              autoCapitalize="none"
+              autoComplete="password"
+              placeholder="Confirm password"
+              placeholderTextColor="#888"
+              secureTextEntry
+              style={styles.input}
+              value={confirmPassword}
+              onChangeText={setConfirmPassword}
+            />
+          </View>
+
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Company profile</Text>
+            <Text style={styles.sectionSubtitle}>
+              We’ll preload every estimate with this information. You can tweak it anytime in Settings.
+            </Text>
+            <LogoPicker value={logoUri} onChange={setLogoUri} />
+            <TextInput
+              placeholder="Company name"
+              placeholderTextColor="#888"
+              style={styles.input}
+              value={companyName}
+              onChangeText={setCompanyName}
+            />
+            <TextInput
+              placeholder="Company email"
+              placeholderTextColor="#888"
+              keyboardType="email-address"
+              autoCapitalize="none"
+              style={styles.input}
+              value={companyEmail}
+              onChangeText={setCompanyEmail}
+            />
+            <TextInput
+              placeholder="Phone"
+              placeholderTextColor="#888"
+              keyboardType="phone-pad"
+              style={styles.input}
+              value={companyPhone}
+              onChangeText={setCompanyPhone}
+            />
+            <TextInput
+              placeholder="Website"
+              placeholderTextColor="#888"
+              autoCapitalize="none"
+              style={styles.input}
+              value={companyWebsite}
+              onChangeText={setCompanyWebsite}
+            />
+            <TextInput
+              placeholder="Business address"
+              placeholderTextColor="#888"
+              style={[styles.input, styles.textArea]}
+              value={companyAddress}
+              onChangeText={setCompanyAddress}
+              multiline
+            />
+          </View>
+
+          <Pressable style={[styles.button, loading && styles.buttonDisabled]} onPress={handleSignup} disabled={loading}>
+            <Text style={styles.buttonText}>{loading ? "Creating account..." : "Sign up"}</Text>
+          </Pressable>
+          <View style={styles.linksRow}>
+            <Link href="/(auth)/login" style={styles.link}>
+              Already have an account?
+            </Link>
+          </View>
         </View>
-        <Text style={styles.title}>Create your account</Text>
-        <TextInput
-          autoCapitalize="none"
-          autoComplete="email"
-          autoCorrect={false}
-          keyboardType="email-address"
-          placeholder="Email"
-          placeholderTextColor="#888"
-          style={styles.input}
-          value={email}
-          onChangeText={setEmail}
-        />
-        <TextInput
-          autoCapitalize="none"
-          autoComplete="password"
-          placeholder="Password"
-          placeholderTextColor="#888"
-          secureTextEntry
-          style={styles.input}
-          value={password}
-          onChangeText={setPassword}
-        />
-        <TextInput
-          autoCapitalize="none"
-          autoComplete="password"
-          placeholder="Confirm password"
-          placeholderTextColor="#888"
-          secureTextEntry
-          style={styles.input}
-          value={confirmPassword}
-          onChangeText={setConfirmPassword}
-        />
-        <Pressable style={[styles.button, loading && styles.buttonDisabled]} onPress={handleSignup} disabled={loading}>
-          <Text style={styles.buttonText}>{loading ? "Creating account..." : "Sign up"}</Text>
-        </Pressable>
-        <View style={styles.linksRow}>
-          <Link href="/(auth)/login" style={styles.link}>
-            Already have an account?
-          </Link>
-        </View>
-      </View>
+      </ScrollView>
     </KeyboardAvoidingView>
   );
 }
@@ -119,12 +204,15 @@ const styles = StyleSheet.create({
     backgroundColor: "#fff",
     borderRadius: 16,
     padding: 24,
-    gap: 16,
+    gap: 20,
     shadowColor: "#000",
     shadowOpacity: 0.15,
     shadowOffset: { width: 0, height: 8 },
     shadowRadius: 12,
     elevation: 6,
+  },
+  scrollContent: {
+    paddingVertical: 24,
   },
   logoContainer: {
     alignItems: "center",
@@ -136,6 +224,18 @@ const styles = StyleSheet.create({
     color: "#0f172a",
     textAlign: "center",
   },
+  section: {
+    gap: 12,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: "#0f172a",
+  },
+  sectionSubtitle: {
+    fontSize: 14,
+    color: "#475569",
+  },
   input: {
     borderWidth: 1,
     borderColor: "#e2e8f0",
@@ -144,6 +244,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     fontSize: 16,
     color: "#0f172a",
+  },
+  textArea: {
+    minHeight: 90,
+    textAlignVertical: "top",
   },
   button: {
     backgroundColor: "#2563eb",

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -12,6 +12,7 @@ import {
 import Slider from "@react-native-community/slider";
 import { useAuth } from "../../context/AuthContext";
 import { useSettings } from "../../context/SettingsContext";
+import LogoPicker from "../../components/LogoPicker";
 
 const THEME_OPTIONS = [
   { label: "Light", value: "light" },
@@ -36,6 +37,7 @@ export default function Settings() {
     setHapticIntensity,
     setNotificationsEnabled,
     setAutoSyncEnabled,
+    setCompanyProfile,
     triggerHaptic,
     resetToDefaults,
   } = useSettings();
@@ -194,6 +196,27 @@ export default function Settings() {
       color: colors.primaryText,
       backgroundColor: colors.isDark ? "rgba(15, 23, 42, 0.7)" : "#f8fafc",
     },
+    textArea: {
+      borderWidth: 1,
+      borderColor: colors.border,
+      borderRadius: 12,
+      paddingHorizontal: 12,
+      paddingVertical: 10,
+      fontSize: 16,
+      color: colors.primaryText,
+      backgroundColor: colors.isDark ? "rgba(15, 23, 42, 0.7)" : "#f8fafc",
+      minHeight: 90,
+      textAlignVertical: "top",
+    },
+    fieldLabel: {
+      fontSize: 15,
+      fontWeight: "600",
+      color: colors.primaryText,
+      marginBottom: 6,
+    },
+    logoSection: {
+      gap: 16,
+    },
     percentSuffix: {
       fontSize: 16,
       fontWeight: "600",
@@ -256,6 +279,74 @@ export default function Settings() {
   return (
     <View style={themedStyles.container}>
       <ScrollView contentContainerStyle={themedStyles.content} showsVerticalScrollIndicator={false}>
+        <View style={[themedStyles.section, themedStyles.logoSection]}>
+          <Text style={themedStyles.sectionHeader}>Company profile</Text>
+          <Text style={themedStyles.sectionDescription}>
+            Keep these details current so new estimates automatically display your brand.
+          </Text>
+          <LogoPicker
+            value={settings.companyProfile.logoUri}
+            onChange={(uri) => setCompanyProfile({ logoUri: uri })}
+          />
+          <View style={{ gap: 16 }}>
+            <View>
+              <Text style={themedStyles.fieldLabel}>Company name</Text>
+              <TextInput
+                value={settings.companyProfile.name}
+                onChangeText={(text) => setCompanyProfile({ name: text })}
+                placeholder="QuickQuote Construction"
+                placeholderTextColor={colors.secondaryText}
+                style={themedStyles.textField}
+              />
+            </View>
+            <View>
+              <Text style={themedStyles.fieldLabel}>Email</Text>
+              <TextInput
+                value={settings.companyProfile.email}
+                onChangeText={(text) => setCompanyProfile({ email: text })}
+                placeholder="hello@quickquote.com"
+                placeholderTextColor={colors.secondaryText}
+                keyboardType="email-address"
+                autoCapitalize="none"
+                style={themedStyles.textField}
+              />
+            </View>
+            <View>
+              <Text style={themedStyles.fieldLabel}>Phone</Text>
+              <TextInput
+                value={settings.companyProfile.phone}
+                onChangeText={(text) => setCompanyProfile({ phone: text })}
+                placeholder="(555) 123-4567"
+                placeholderTextColor={colors.secondaryText}
+                keyboardType="phone-pad"
+                style={themedStyles.textField}
+              />
+            </View>
+            <View>
+              <Text style={themedStyles.fieldLabel}>Website</Text>
+              <TextInput
+                value={settings.companyProfile.website}
+                onChangeText={(text) => setCompanyProfile({ website: text })}
+                placeholder="quickquote.com"
+                placeholderTextColor={colors.secondaryText}
+                autoCapitalize="none"
+                style={themedStyles.textField}
+              />
+            </View>
+            <View>
+              <Text style={themedStyles.fieldLabel}>Address</Text>
+              <TextInput
+                value={settings.companyProfile.address}
+                onChangeText={(text) => setCompanyProfile({ address: text })}
+                placeholder="123 Main Street, Springfield, USA"
+                placeholderTextColor={colors.secondaryText}
+                multiline
+                style={themedStyles.textArea}
+              />
+            </View>
+          </View>
+        </View>
+
         <View style={themedStyles.section}>
           <Text style={themedStyles.sectionHeader}>Appearance</Text>
           <Text style={themedStyles.sectionDescription}>

--- a/components/LogoPicker.tsx
+++ b/components/LogoPicker.tsx
@@ -1,0 +1,165 @@
+import { useCallback } from "react";
+import {
+  Alert,
+  Image,
+  Pressable,
+  StyleSheet,
+  Text,
+  useColorScheme,
+  View,
+} from "react-native";
+import * as ImagePicker from "expo-image-picker";
+import BrandLogo from "./BrandLogo";
+
+type LogoPickerProps = {
+  label?: string;
+  value: string | null;
+  onChange: (uri: string | null) => void;
+};
+
+export function LogoPicker({ label = "Company logo", value, onChange }: LogoPickerProps) {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === "dark";
+
+  const handlePick = useCallback(async () => {
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+
+    if (!permission.granted) {
+      Alert.alert(
+        "Permission needed",
+        "We need access to your photo library so you can choose a company logo."
+      );
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.8,
+      allowsEditing: true,
+    });
+
+    if (result.canceled || !result.assets?.length) {
+      return;
+    }
+
+    const [asset] = result.assets;
+    if (asset?.uri) {
+      onChange(asset.uri);
+    }
+  }, [onChange]);
+
+  const handleRemove = useCallback(() => {
+    onChange(null);
+  }, [onChange]);
+
+  const palette = {
+    text: isDark ? "#e2e8f0" : "#1f2937",
+    muted: isDark ? "#94a3b8" : "#475569",
+    surface: isDark ? "#1e293b" : "#f8fafc",
+    border: isDark ? "#334155" : "#cbd5f5",
+    accent: "#2563eb",
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.label, { color: palette.text }]}>{label}</Text>
+      <View style={styles.previewRow}>
+        <View
+          style={[
+            styles.previewContainer,
+            { backgroundColor: palette.surface, borderColor: palette.border },
+          ]}
+        >
+          {value ? (
+            <Image
+              source={{ uri: value }}
+              resizeMode="contain"
+              style={styles.previewImage}
+            />
+          ) : (
+            <BrandLogo size={64} style={styles.placeholderLogo} />
+          )}
+        </View>
+        <View style={styles.actions}>
+          <Pressable
+            style={[
+              styles.button,
+              styles.primaryButton,
+              { backgroundColor: palette.accent, borderColor: palette.accent },
+            ]}
+            onPress={handlePick}
+          >
+            <Text style={[styles.buttonText, styles.primaryButtonText]}>
+              {value ? "Replace logo" : "Upload logo"}
+            </Text>
+          </Pressable>
+          {value ? (
+            <Pressable
+              style={[
+                styles.button,
+                { backgroundColor: palette.surface, borderColor: palette.border },
+              ]}
+              onPress={handleRemove}
+            >
+              <Text style={[styles.buttonText, { color: palette.text }]}>Remove logo</Text>
+            </Pressable>
+          ) : null}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 8,
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  previewRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 16,
+  },
+  previewContainer: {
+    width: 88,
+    height: 88,
+    borderRadius: 18,
+    borderWidth: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    overflow: "hidden",
+  },
+  previewImage: {
+    width: "100%",
+    height: "100%",
+  },
+  placeholderLogo: {
+    opacity: 0.7,
+  },
+  actions: {
+    flex: 1,
+    gap: 8,
+  },
+  button: {
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  buttonText: {
+    textAlign: "center",
+    fontWeight: "600",
+  },
+  primaryButton: {
+    backgroundColor: "#2563eb",
+    borderColor: "#2563eb",
+  },
+  primaryButtonText: {
+    color: "#fff",
+  },
+});
+
+export default LogoPicker;


### PR DESCRIPTION
## Summary
- add a reusable logo picker component and extend settings with company profile fields that persist across the app
- collect company branding during signup and expose company details throughout the new single-page estimate form with inline item editing and saved item support
- refresh tests to reflect the streamlined estimate workflow and expanded settings state

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dc04a3a004832396ee7d16681efff5