### PR TITLE
Improve estimate sharing and refresh app theme

### DIFF
--- a/__tests__/editEstimateItems.test.tsx
+++ b/__tests__/editEstimateItems.test.tsx
@@ -202,7 +202,7 @@ describe("EditEstimateScreen - item editing", () => {
     const { findByText, getByText } = render(<EditEstimateScreen />);
 
     await act(async () => {});
-    await findByText("Items");
+    await findByText("Estimate items");
 
     fireEvent.press(getByText("Add Item"));
 

--- a/app/(tabs)/customers.tsx
+++ b/app/(tabs)/customers.tsx
@@ -4,6 +4,7 @@ import {
   Alert,
   Button,
   FlatList,
+  StyleSheet,
   Text,
   TextInput,
   View,
@@ -11,6 +12,7 @@ import {
 import CustomerForm from "../../components/CustomerForm";
 import { openDB, queueChange } from "../../lib/sqlite";
 import { runSync } from "../../lib/sync";
+import { cardShadow, palette } from "../../lib/theme";
 
 type CustomerRecord = {
   id: string;
@@ -106,51 +108,64 @@ function EditCustomerForm({ customer, onCancel, onSaved }: EditCustomerFormProps
   }, [address, customer, email, name, notes, phone, onSaved]);
 
   return (
-    <View style={{ gap: 8, padding: 12, borderWidth: 1, borderRadius: 8 }}>
-      <Text style={{ fontWeight: "600", fontSize: 16 }}>Edit Customer</Text>
+    <View style={styles.editCard}>
+      <Text style={styles.editTitle}>Edit Customer</Text>
       <TextInput
         placeholder="Name"
+        placeholderTextColor={palette.mutedText}
         value={name}
         onChangeText={setName}
-        style={{ borderWidth: 1, borderRadius: 6, padding: 10 }}
+        style={styles.input}
       />
       <TextInput
         placeholder="Phone"
+        placeholderTextColor={palette.mutedText}
         value={phone}
         onChangeText={setPhone}
-        style={{ borderWidth: 1, borderRadius: 6, padding: 10 }}
+        style={styles.input}
       />
       <TextInput
         placeholder="Email"
+        placeholderTextColor={palette.mutedText}
         value={email}
         onChangeText={setEmail}
         autoCapitalize="none"
         keyboardType="email-address"
-        style={{ borderWidth: 1, borderRadius: 6, padding: 10 }}
+        style={styles.input}
       />
       <TextInput
         placeholder="Address"
+        placeholderTextColor={palette.mutedText}
         value={address}
         onChangeText={setAddress}
-        style={{ borderWidth: 1, borderRadius: 6, padding: 10 }}
+        style={styles.input}
       />
       <TextInput
         placeholder="Account notes"
+        placeholderTextColor={palette.mutedText}
         value={notes}
         onChangeText={setNotes}
         multiline
         numberOfLines={3}
-        style={{
-          borderWidth: 1,
-          borderRadius: 6,
-          padding: 10,
-          textAlignVertical: "top",
-          minHeight: 90,
-        }}
+        style={styles.textArea}
       />
-      <View style={{ flexDirection: "row", gap: 12, justifyContent: "flex-end" }}>
-        <Button title="Cancel" onPress={onCancel} disabled={saving} />
-        <Button title="Save" onPress={saveChanges} disabled={saving} />
+      <View style={styles.inlineButtons}>
+        <View style={styles.buttonFlex}>
+          <Button
+            title="Cancel"
+            onPress={onCancel}
+            disabled={saving}
+            color={palette.secondaryText}
+          />
+        </View>
+        <View style={styles.buttonFlex}>
+          <Button
+            title="Save"
+            onPress={saveChanges}
+            disabled={saving}
+            color={palette.accent}
+          />
+        </View>
       </View>
     </View>
   );
@@ -266,44 +281,35 @@ export default function Customers() {
 
   const renderCustomer = useCallback(
     ({ item }: { item: CustomerRecord }) => (
-      <View
-        style={{
-          padding: 16,
-          borderWidth: 1,
-          borderRadius: 10,
-          marginBottom: 12,
-          backgroundColor: "#fff",
-        }}
-      >
-        <Text style={{ fontSize: 18, fontWeight: "600" }}>{item.name}</Text>
+      <View style={styles.customerCard}>
+        <Text style={styles.customerName}>{item.name}</Text>
         {item.email ? (
-          <Text style={{ color: "#555", marginTop: 4 }}>{item.email}</Text>
+          <Text style={styles.customerMeta}>{item.email}</Text>
         ) : null}
         {item.phone ? (
-          <Text style={{ color: "#555", marginTop: 2 }}>{item.phone}</Text>
+          <Text style={styles.customerMeta}>{item.phone}</Text>
         ) : null}
         {item.address ? (
-          <Text style={{ color: "#555", marginTop: 2 }}>{item.address}</Text>
+          <Text style={styles.customerMeta}>{item.address}</Text>
         ) : null}
         {item.notes ? (
-          <Text style={{ color: "#777", marginTop: 6, fontStyle: "italic" }}>
-            {item.notes}
-          </Text>
+          <Text style={styles.customerNotes}>{item.notes}</Text>
         ) : null}
-        <View style={{ flexDirection: "row", gap: 12, marginTop: 12 }}>
-          <View style={{ flex: 1 }}>
+        <View style={styles.inlineButtons}>
+          <View style={styles.buttonFlex}>
             <Button
               title="Edit"
+              color={palette.accent}
               onPress={() => {
                 setEditingCustomer(item);
                 setShowAddForm(false);
               }}
             />
           </View>
-          <View style={{ flex: 1 }}>
+          <View style={styles.buttonFlex}>
             <Button
               title="Delete"
-              color="#b00020"
+              color={palette.danger}
               onPress={() => handleDelete(item)}
             />
           </View>
@@ -314,26 +320,23 @@ export default function Customers() {
   );
 
   return (
-    <View style={{ flex: 1, padding: 16, backgroundColor: "#f5f5f5" }}>
+    <View style={styles.screen}>
       <FlatList
         data={filteredCustomers}
         keyExtractor={(item) => item.id}
         renderItem={renderCustomer}
         ListHeaderComponent={
-          <View style={{ gap: 12, marginBottom: 16 }}>
-            <Text style={{ fontSize: 24, fontWeight: "700" }}>
-              Customer Management
+          <View style={styles.header}>
+            <Text style={styles.title}>Customer management</Text>
+            <Text style={styles.subtitle}>
+              Keep every relationship organized with quick notes and contact details.
             </Text>
             <TextInput
               placeholder="Search by name, email, phone, address, or notes"
+              placeholderTextColor={palette.mutedText}
               value={search}
               onChangeText={setSearch}
-              style={{
-                borderWidth: 1,
-                borderRadius: 8,
-                padding: 10,
-                backgroundColor: "#fff",
-              }}
+              style={styles.input}
             />
             <Button
               title={showAddForm ? "Hide Add Customer" : "Add Customer"}
@@ -341,9 +344,10 @@ export default function Customers() {
                 setShowAddForm((prev) => !prev);
                 setEditingCustomer(null);
               }}
+              color={palette.accent}
             />
             {showAddForm ? (
-              <View style={{ padding: 12, borderWidth: 1, borderRadius: 8 }}>
+              <View style={styles.formCard}>
                 <CustomerForm
                   onSaved={() => {
                     setShowAddForm(false);
@@ -369,16 +373,136 @@ export default function Customers() {
               />
             ) : null}
             {loading ? (
-              <View style={{ paddingVertical: 20 }}>
-                <ActivityIndicator />
+              <View style={styles.loadingRow}>
+                <ActivityIndicator color={palette.accent} />
               </View>
             ) : null}
           </View>
         }
         ListEmptyComponent={
           !loading ? (
-            <View style={{ paddingVertical: 40 }}>
-              <Text style={{ textAlign: "center", color: "#666" }}>
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyText}>No customers found.</Text>
+            </View>
+          ) : null
+        }
+        contentContainerStyle={styles.listContent}
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+    backgroundColor: palette.background,
+  },
+  header: {
+    gap: 12,
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 26,
+    fontWeight: "700",
+    color: palette.primaryText,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: palette.secondaryText,
+    lineHeight: 20,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: palette.border,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: palette.surface,
+    color: palette.primaryText,
+    ...cardShadow(4),
+  },
+  textArea: {
+    borderWidth: 1,
+    borderColor: palette.border,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    backgroundColor: palette.surface,
+    color: palette.primaryText,
+    minHeight: 90,
+    textAlignVertical: "top",
+  },
+  formCard: {
+    padding: 16,
+    borderRadius: 18,
+    backgroundColor: palette.surface,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: palette.border,
+    ...cardShadow(10),
+  },
+  editCard: {
+    gap: 10,
+    padding: 16,
+    borderRadius: 18,
+    backgroundColor: palette.surface,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: palette.border,
+    ...cardShadow(10),
+  },
+  editTitle: {
+    fontWeight: "600",
+    fontSize: 16,
+    color: palette.primaryText,
+  },
+  inlineButtons: {
+    flexDirection: "row",
+    gap: 12,
+    marginTop: 8,
+  },
+  buttonFlex: {
+    flex: 1,
+  },
+  customerCard: {
+    backgroundColor: palette.surface,
+    borderRadius: 20,
+    padding: 18,
+    marginBottom: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: palette.border,
+    ...cardShadow(12),
+    gap: 6,
+  },
+  customerName: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: palette.primaryText,
+  },
+  customerMeta: {
+    color: palette.secondaryText,
+  },
+  customerNotes: {
+    marginTop: 6,
+    color: palette.mutedText,
+    fontStyle: "italic",
+  },
+  loadingRow: {
+    paddingVertical: 16,
+  },
+  emptyState: {
+    paddingVertical: 40,
+    alignItems: "center",
+  },
+  emptyText: {
+    color: palette.mutedText,
+  },
+  listContent: {
+    paddingBottom: 24,
+  },
+});
                 No customers found.
               </Text>
             </View>

--- a/app/(tabs)/estimates/[id].tsx
+++ b/app/(tabs)/estimates/[id].tsx
@@ -10,6 +10,7 @@ import {
   Linking,
   Platform,
   ScrollView,
+  StyleSheet,
   Text,
   TextInput,
   View,
@@ -55,6 +56,7 @@ import {
 } from "../../../lib/pdf";
 import { calculateEstimateTotals } from "../../../lib/estimateMath";
 import { formatPercentageInput } from "../../../lib/numberFormat";
+import { cardShadow, palette } from "../../../lib/theme";
 import type { EstimateListItem } from "./index";
 import { v4 as uuidv4 } from "uuid";
 
@@ -213,6 +215,7 @@ export default function EditEstimateScreen() {
   );
   const estimateRef = useRef<EstimateListItem | null>(null);
   const lastPdfRef = useRef<EstimatePdfResult | null>(null);
+  const releasePdfRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     if (hasRestoredDraftRef.current) {
@@ -454,17 +457,19 @@ export default function EditEstimateScreen() {
 
   useEffect(() => {
     lastPdfRef.current = null;
+    if (releasePdfRef.current) {
+      releasePdfRef.current();
+      releasePdfRef.current = null;
+    }
   }, [pdfOptions]);
 
-  const ensureNativePdfSupport = useCallback(() => {
-    if (Platform.OS === "web") {
-      Alert.alert(
-        "Unavailable",
-        "PDF preview and sharing are only available on iOS and Android."
-      );
-      return false;
-    }
-    return true;
+  useEffect(() => {
+    return () => {
+      if (releasePdfRef.current) {
+        releasePdfRef.current();
+        releasePdfRef.current = null;
+      }
+    };
   }, []);
 
   const openItemEditorScreen = useCallback(
@@ -779,28 +784,21 @@ export default function EditEstimateScreen() {
 
   const renderItem = useCallback(
     ({ item }: { item: EstimateItemRecord }) => (
-      <View
-        style={{
-          padding: 12,
-          borderWidth: 1,
-          borderRadius: 8,
-          backgroundColor: "#fafafa",
-          gap: 8,
-        }}
-      >
-        <View style={{ gap: 2 }}>
-          <Text style={{ fontWeight: "600" }}>{item.description}</Text>
-          <Text style={{ color: "#555" }}>
+      <View style={styles.itemCard}>
+        <View style={styles.itemInfo}>
+          <Text style={styles.itemTitle}>{item.description}</Text>
+          <Text style={styles.itemMeta}>
             Qty: {item.quantity} @ {formatCurrency(item.unit_price)}
           </Text>
-          <Text style={{ color: "#555" }}>
+          <Text style={styles.itemMeta}>
             Line Total: {formatCurrency(item.total)}
           </Text>
         </View>
-        <View style={{ flexDirection: "row", gap: 12 }}>
-          <View style={{ flex: 1 }}>
+        <View style={styles.inlineButtons}>
+          <View style={styles.buttonFlex}>
             <Button
               title="Edit"
+              color={palette.accent}
               onPress={() =>
                 openItemEditorScreen({
                   title: "Edit Item",
@@ -811,16 +809,16 @@ export default function EditEstimateScreen() {
                     unit_price: item.unit_price,
                   },
                   initialTemplateId: item.catalog_item_id,
-                  templates: savedItemTemplates,
+                  templates: () => savedItemTemplates,
                   onSubmit: makeItemSubmitHandler(item),
                 })
               }
             />
           </View>
-          <View style={{ flex: 1 }}>
+          <View style={styles.buttonFlex}>
             <Button
               title="Remove"
-              color="#b00020"
+              color={palette.danger}
               onPress={() => handleDeleteItem(item)}
             />
           </View>
@@ -1021,10 +1019,6 @@ export default function EditEstimateScreen() {
   }, [refreshPhotosFromDb]);
 
   const ensurePdfReady = useCallback(async () => {
-    if (!ensureNativePdfSupport()) {
-      return null;
-    }
-
     if (!pdfOptions) {
       Alert.alert("Missing data", "Unable to build the estimate PDF.");
       return null;
@@ -1035,7 +1029,24 @@ export default function EditEstimateScreen() {
       if (cached) {
         return cached;
       }
+      if (releasePdfRef.current) {
+        releasePdfRef.current();
+        releasePdfRef.current = null;
+      }
       const result = await renderEstimatePdf(pdfOptions);
+      if (
+        Platform.OS === "web" &&
+        typeof URL !== "undefined" &&
+        result.uri.startsWith("blob:")
+      ) {
+        releasePdfRef.current = () => {
+          try {
+            URL.revokeObjectURL(result.uri);
+          } catch (error) {
+            console.warn("Failed to release PDF preview", error);
+          }
+        };
+      }
       lastPdfRef.current = result;
       return result;
     } catch (error) {
@@ -1043,13 +1054,34 @@ export default function EditEstimateScreen() {
       Alert.alert("Error", "Unable to prepare the PDF. Please try again.");
       return null;
     }
-  }, [ensureNativePdfSupport, pdfOptions]);
+  }, [pdfOptions]);
 
   const handlePreviewPdf = useCallback(async () => {
     setPdfWorking(true);
     try {
       const pdf = await ensurePdfReady();
       if (!pdf) {
+        return;
+      }
+
+      if (Platform.OS === "web") {
+        if (typeof window === "undefined") {
+          Alert.alert(
+            "Unavailable",
+            "Preview is not supported in this environment."
+          );
+          return;
+        }
+        const previewWindow = window.open("", "_blank");
+        if (!previewWindow) {
+          Alert.alert(
+            "Popup blocked",
+            "Allow popups to preview the estimate."
+          );
+          return;
+        }
+        previewWindow.document.write(pdf.html);
+        previewWindow.document.close();
         return;
       }
 
@@ -1061,6 +1093,55 @@ export default function EditEstimateScreen() {
       setPdfWorking(false);
     }
   }, [ensurePdfReady]);
+
+  const markEstimateSent = useCallback(
+    async (channel: "email" | "sms") => {
+      const current = estimateRef.current;
+      if (!current || current.status?.toLowerCase() === "sent") {
+        if (status !== "sent") {
+          setStatus("sent");
+        }
+        return;
+      }
+
+      try {
+        const now = new Date().toISOString();
+        const nextVersion = (current.version ?? 1) + 1;
+        const db = await openDB();
+        await db.runAsync(
+          `UPDATE estimates
+           SET status = ?, version = ?, updated_at = ?
+           WHERE id = ?`,
+          ["sent", nextVersion, now, current.id]
+        );
+
+        const updated: EstimateListItem = {
+          ...current,
+          status: "sent",
+          version: nextVersion,
+          updated_at: now,
+        };
+
+        estimateRef.current = updated;
+        setEstimate(updated);
+        setStatus("sent");
+
+        await queueChange(
+          "estimates",
+          "update",
+          sanitizeEstimateForQueue(updated)
+        );
+        await runSync();
+      } catch (error) {
+        console.error("Failed to update estimate status", error);
+        Alert.alert(
+          "Status",
+          `Your estimate was ${channel === "email" ? "emailed" : "texted"}, but we couldn't update the status automatically. Please review it manually.`
+        );
+      }
+    },
+    [setEstimate, setStatus, status]
+  );
 
   const handleShareEmail = useCallback(async () => {
     if (!estimate) {
@@ -1111,6 +1192,15 @@ export default function EditEstimateScreen() {
 
       await Linking.openURL(mailto);
 
+      if (Platform.OS === "web" && typeof document !== "undefined") {
+        const link = document.createElement("a");
+        link.href = pdf.uri;
+        link.download = pdf.fileName;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      }
+
       await logEstimateDelivery({
         estimateId: estimate.id,
         channel: "email",
@@ -1121,6 +1211,7 @@ export default function EditEstimateScreen() {
             : bodyPlain,
         metadata: { pdfUri: pdf.uri, mailto },
       });
+      await markEstimateSent("email");
     } catch (error) {
       console.error("Failed to share via email", error);
       Alert.alert("Error", "Unable to share the estimate via email.");
@@ -1196,6 +1287,7 @@ export default function EditEstimateScreen() {
           smsResult: smsResponse?.result ?? null,
         },
       });
+      await markEstimateSent("sms");
     } catch (error) {
       console.error("Failed to share via SMS", error);
       Alert.alert("Error", "Unable to share the estimate via SMS.");
@@ -1524,8 +1616,8 @@ export default function EditEstimateScreen() {
 
   if (loading) {
     return (
-      <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
-        <ActivityIndicator />
+      <View style={styles.loadingState}>
+        <ActivityIndicator color={palette.accent} />
       </View>
     );
   }
@@ -1535,40 +1627,39 @@ export default function EditEstimateScreen() {
   }
 
   return (
-    <ScrollView
-      contentContainerStyle={{ padding: 16, gap: 16 }}
-      style={{ flex: 1, backgroundColor: "#fff" }}
-    >
-      <Text style={{ fontSize: 20, fontWeight: "600" }}>Edit Estimate</Text>
-      <CustomerPicker
-        selectedCustomer={customerId}
-        onSelect={(id) => setCustomerId(id)}
-      />
-
-      <View style={{ gap: 6 }}>
-        <Text style={{ fontWeight: "600" }}>Date</Text>
-        <TextInput
-          placeholder="YYYY-MM-DD"
-          value={estimateDate}
-          onChangeText={setEstimateDate}
-          style={{ borderWidth: 1, borderRadius: 8, padding: 10 }}
-        />
+    <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
+      <View style={styles.card}>
+        <Text style={styles.pageTitle}>Edit Estimate</Text>
+        <Text style={styles.sectionSubtitle}>
+          Update pricing, attach photos, and send a polished quote in seconds.
+        </Text>
+        <View style={styles.fieldGroup}>
+          <Text style={styles.fieldLabel}>Customer</Text>
+          <CustomerPicker
+            selectedCustomer={customerId}
+            onSelect={(id) => setCustomerId(id)}
+          />
+        </View>
+        <View style={styles.fieldGroup}>
+          <Text style={styles.fieldLabel}>Date</Text>
+          <TextInput
+            placeholder="YYYY-MM-DD"
+            placeholderTextColor={palette.mutedText}
+            value={estimateDate}
+            onChangeText={setEstimateDate}
+            style={styles.input}
+          />
+        </View>
       </View>
 
-      <View style={{ gap: 12 }}>
-        <Text style={{ fontWeight: "600" }}>Photos</Text>
+      <View style={styles.card}>
+        <Text style={styles.sectionTitle}>Photos</Text>
+        <Text style={styles.sectionSubtitle}>
+          Give your crew context with job site reference shots.
+        </Text>
         {photos.length === 0 ? (
-          <View
-            style={{
-              padding: 16,
-              borderWidth: 1,
-              borderRadius: 8,
-              borderStyle: "dashed",
-              alignItems: "center",
-              backgroundColor: "#fafafa",
-            }}
-          >
-            <Text style={{ color: "#666" }}>No photos attached yet.</Text>
+          <View style={styles.emptyCard}>
+            <Text style={styles.emptyText}>No photos attached yet.</Text>
           </View>
         ) : (
           photos.map((photo) => {
@@ -1577,34 +1668,16 @@ export default function EditEstimateScreen() {
             const isDeleting = photoDeletingId === photo.id;
 
             return (
-              <View
-                key={photo.id}
-                style={{
-                  borderWidth: 1,
-                  borderRadius: 8,
-                  padding: 12,
-                  gap: 12,
-                  backgroundColor: "#fafafa",
-                }}
-              >
+              <View key={photo.id} style={styles.photoCard}>
                 {photo.local_uri ? (
                   <Image
                     source={{ uri: photo.local_uri }}
-                    style={{ width: "100%", height: 180, borderRadius: 8 }}
+                    style={styles.photoImage}
                     resizeMode="cover"
                   />
                 ) : (
-                  <View
-                    style={{
-                      height: 180,
-                      borderRadius: 8,
-                      alignItems: "center",
-                      justifyContent: "center",
-                      backgroundColor: "#eee",
-                      paddingHorizontal: 12,
-                    }}
-                  >
-                    <Text style={{ color: "#555", textAlign: "center" }}>
+                  <View style={styles.photoPlaceholder}>
+                    <Text style={styles.photoPlaceholderText}>
                       Photo unavailable offline. Use sync to restore the local
                       copy.
                     </Text>
@@ -1612,31 +1685,26 @@ export default function EditEstimateScreen() {
                 )}
                 <TextInput
                   placeholder="Add a description"
+                  placeholderTextColor={palette.mutedText}
                   value={draft}
                   onChangeText={(text) => handlePhotoDraftChange(photo.id, text)}
                   multiline
                   numberOfLines={3}
-                  style={{
-                    borderWidth: 1,
-                    borderRadius: 8,
-                    padding: 10,
-                    minHeight: 80,
-                    textAlignVertical: "top",
-                    backgroundColor: "#fff",
-                  }}
+                  style={styles.textArea}
                 />
-                <View style={{ flexDirection: "row", gap: 12 }}>
-                  <View style={{ flex: 1 }}>
+                <View style={styles.inlineButtons}>
+                  <View style={styles.buttonFlex}>
                     <Button
                       title="Save"
+                      color={palette.accent}
                       onPress={() => handleSavePhotoDescription(photo)}
                       disabled={isSaving}
                     />
                   </View>
-                  <View style={{ flex: 1 }}>
+                  <View style={styles.buttonFlex}>
                     <Button
                       title="Remove"
-                      color="#b00020"
+                      color={palette.danger}
                       onPress={() => handleDeletePhoto(photo)}
                       disabled={isDeleting}
                     />
@@ -1651,45 +1719,42 @@ export default function EditEstimateScreen() {
             title={photoSyncing ? "Syncing photos..." : "Sync photos"}
             onPress={handleRetryPhotoSync}
             disabled={photoSyncing}
+            color={palette.accent}
           />
         ) : null}
         <Button
           title={addingPhoto ? "Adding photo..." : "Add Photo"}
           onPress={handleAddPhoto}
           disabled={addingPhoto}
+          color={palette.accent}
         />
       </View>
 
-      <View style={{ gap: 12 }}>
-        <Text style={{ fontWeight: "600" }}>Items</Text>
+      <View style={styles.card}>
+        <Text style={styles.sectionTitle}>Estimate items</Text>
+        <Text style={styles.sectionSubtitle}>
+          Track the work you&apos;re quoting. Saved items help you move fast.
+        </Text>
         <FlatList
           data={items}
           keyExtractor={(item) => item.id}
           renderItem={renderItem}
           scrollEnabled={false}
-          ItemSeparatorComponent={() => <View style={{ height: 12 }} />}
+          ItemSeparatorComponent={() => <View style={styles.itemSeparator} />}
           ListEmptyComponent={
-            <View
-              style={{
-                padding: 16,
-                borderWidth: 1,
-                borderRadius: 8,
-                borderStyle: "dashed",
-                alignItems: "center",
-                backgroundColor: "#fafafa",
-              }}
-            >
-              <Text style={{ color: "#666" }}>No items added yet.</Text>
+            <View style={styles.emptyCard}>
+              <Text style={styles.emptyText}>No items added yet.</Text>
             </View>
           }
         />
         <Button
           title="Add Item"
+          color={palette.accent}
           onPress={() =>
             openItemEditorScreen({
               title: "Add Item",
               submitLabel: "Add Item",
-              templates: savedItemTemplates,
+              templates: () => savedItemTemplates,
               initialTemplateId: null,
               onSubmit: makeItemSubmitHandler(null),
             })
@@ -1697,128 +1762,345 @@ export default function EditEstimateScreen() {
         />
       </View>
 
-      <View style={{ gap: 12 }}>
-        <Text style={{ fontWeight: "600" }}>Labor</Text>
-        <View style={{ gap: 6 }}>
-          <Text style={{ fontWeight: "500" }}>Project hours</Text>
+      <View style={styles.card}>
+        <Text style={styles.sectionTitle}>Labor &amp; tax</Text>
+        <View style={styles.fieldGroup}>
+          <Text style={styles.fieldLabel}>Project hours</Text>
           <TextInput
             placeholder="0"
+            placeholderTextColor={palette.mutedText}
             value={laborHoursText}
             onChangeText={setLaborHoursText}
             keyboardType="decimal-pad"
-            style={{ borderWidth: 1, borderRadius: 8, padding: 10 }}
+            style={styles.input}
           />
         </View>
-        <View style={{ gap: 6 }}>
-          <Text style={{ fontWeight: "500" }}>Hourly rate</Text>
-          <View style={{ flexDirection: "row", alignItems: "center" }}>
-            <Text style={{ fontWeight: "600", marginRight: 8 }}>$</Text>
+        <View style={styles.fieldGroup}>
+          <Text style={styles.fieldLabel}>Hourly rate</Text>
+          <View style={styles.inputRow}>
+            <Text style={styles.prefixSymbol}>$</Text>
             <TextInput
               placeholder="0.00"
+              placeholderTextColor={palette.mutedText}
               value={hourlyRateText}
               onChangeText={setHourlyRateText}
               keyboardType="decimal-pad"
-              style={{ flex: 1, borderWidth: 1, borderRadius: 8, padding: 10 }}
+              style={[styles.input, styles.inputGrow]}
             />
           </View>
-          <Text style={{ color: "#555", fontSize: 12 }}>
+          <Text style={styles.helpText}>
             Labor total (not shown to customers): {formatCurrency(totals.laborTotal)}
           </Text>
         </View>
+        <View style={styles.fieldGroup}>
+          <Text style={styles.fieldLabel}>Tax rate</Text>
+          <View style={styles.inputRow}>
+            <TextInput
+              placeholder="0"
+              placeholderTextColor={palette.mutedText}
+              value={taxRateText}
+              onChangeText={setTaxRateText}
+              keyboardType="decimal-pad"
+              style={[styles.input, styles.inputGrow]}
+            />
+            <Text style={styles.suffixSymbol}>%</Text>
+          </View>
+        </View>
       </View>
 
-      <View style={{ gap: 6 }}>
-        <Text style={{ fontWeight: "600" }}>Tax rate</Text>
-        <View style={{ flexDirection: "row", alignItems: "center" }}>
+      <View style={styles.card}>
+        <Text style={styles.sectionTitle}>Estimate summary</Text>
+        <View style={styles.totalsCard}>
+          <View style={styles.totalsRow}>
+            <Text style={styles.totalsLabel}>Materials</Text>
+            <Text style={styles.totalsValue}>
+              {formatCurrency(totals.materialTotal)}
+            </Text>
+          </View>
+          <View style={styles.totalsRow}>
+            <Text style={styles.totalsLabel}>Labor</Text>
+            <Text style={styles.totalsValue}>
+              {formatCurrency(totals.laborTotal)}
+            </Text>
+          </View>
+          <View style={styles.totalsRow}>
+            <Text style={styles.totalsLabel}>Tax</Text>
+            <Text style={styles.totalsValue}>
+              {formatCurrency(totals.taxTotal)}
+            </Text>
+          </View>
+          <View style={styles.totalsRow}>
+            <Text style={styles.totalsGrand}>Project total</Text>
+            <Text style={styles.totalsGrand}>
+              {formatCurrency(totals.grandTotal)}
+            </Text>
+          </View>
+        </View>
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.sectionTitle}>Status &amp; notes</Text>
+        <View style={styles.fieldGroup}>
+          <Text style={styles.fieldLabel}>Status</Text>
+          <View style={styles.pickerShell}>
+            <Picker selectedValue={status} onValueChange={(value) => setStatus(value)}>
+              {STATUS_OPTIONS.map((option) => (
+                <Picker.Item
+                  key={option.value}
+                  label={option.label}
+                  value={option.value}
+                />
+              ))}
+            </Picker>
+          </View>
+        </View>
+        <View style={styles.fieldGroup}>
+          <Text style={styles.fieldLabel}>Internal notes</Text>
           <TextInput
-            placeholder="0"
-            value={taxRateText}
-            onChangeText={setTaxRateText}
-            keyboardType="decimal-pad"
-            style={{ flex: 1, borderWidth: 1, borderRadius: 8, padding: 10 }}
+            placeholder="Add private notes for your team"
+            placeholderTextColor={palette.mutedText}
+            value={notes}
+            onChangeText={setNotes}
+            multiline
+            numberOfLines={4}
+            style={styles.textArea}
           />
-          <Text style={{ fontWeight: "600", marginLeft: 8 }}>%</Text>
         </View>
       </View>
 
-      <View style={{ gap: 6 }}>
-        <Text style={{ fontWeight: "600" }}>Estimate summary</Text>
-        <View style={{ gap: 4 }}>
-          <Text>Materials: {formatCurrency(totals.materialTotal)}</Text>
-          <Text>Labor: {formatCurrency(totals.laborTotal)}</Text>
-          <Text>Tax: {formatCurrency(totals.taxTotal)}</Text>
-          <Text style={{ fontWeight: "700" }}>Project total: {formatCurrency(totals.grandTotal)}</Text>
-        </View>
-      </View>
-
-      <View style={{ gap: 6 }}>
-        <Text style={{ fontWeight: "600" }}>Status</Text>
-        <View style={{ borderWidth: 1, borderRadius: 8 }}>
-          <Picker selectedValue={status} onValueChange={(value) => setStatus(value)}>
-            {STATUS_OPTIONS.map((option) => (
-              <Picker.Item
-                key={option.value}
-                label={option.label}
-                value={option.value}
-              />
-            ))}
-          </Picker>
-        </View>
-      </View>
-
-      <View style={{ gap: 6 }}>
-        <Text style={{ fontWeight: "600" }}>Notes</Text>
-        <TextInput
-          placeholder="Internal notes"
-          value={notes}
-          onChangeText={setNotes}
-          multiline
-          numberOfLines={4}
-          style={{
-            borderWidth: 1,
-            borderRadius: 8,
-            padding: 10,
-            textAlignVertical: "top",
-            minHeight: 100,
-          }}
+      <View style={styles.card}>
+        <Text style={styles.sectionTitle}>PDF &amp; sharing</Text>
+        <Text style={styles.sectionSubtitle}>
+          Preview your branded estimate and send it straight to the customer.
+        </Text>
+        <Button
+          title="Preview PDF"
+          color={palette.accent}
+          onPress={handlePreviewPdf}
+          disabled={pdfWorking || smsSending}
+        />
+        <Button
+          title="Share via Email"
+          color={palette.accentMuted}
+          onPress={handleShareEmail}
+          disabled={pdfWorking || smsSending}
+        />
+        <Button
+          title="Share via SMS"
+          color={palette.success}
+          onPress={handleShareSms}
+          disabled={smsSending || pdfWorking}
         />
       </View>
 
-      {Platform.OS !== "web" && (
-        <View style={{ gap: 8 }}>
-          <Text style={{ fontWeight: "600" }}>PDF &amp; Sharing</Text>
-          <View>
-            <Button
-              title="Preview PDF"
-              onPress={handlePreviewPdf}
-              disabled={pdfWorking || smsSending}
-            />
-          </View>
-          <View>
-            <Button
-              title="Share via Email"
-              onPress={handleShareEmail}
-              disabled={pdfWorking || smsSending}
-            />
-          </View>
-          <View>
-            <Button
-              title="Share via SMS"
-              onPress={handleShareSms}
-              disabled={smsSending || pdfWorking}
-            />
-          </View>
+      <View style={styles.footerButtons}>
+        <View style={styles.buttonFlex}>
+          <Button
+            title="Cancel"
+            onPress={handleCancel}
+            disabled={saving}
+            color={palette.secondaryText}
+          />
         </View>
-      )}
-
-      <View style={{ flexDirection: "row", gap: 12 }}>
-        <View style={{ flex: 1 }}>
-          <Button title="Cancel" onPress={handleCancel} disabled={saving} />
-        </View>
-        <View style={{ flex: 1 }}>
-          <Button title="Save" onPress={handleSave} disabled={saving} />
+        <View style={styles.buttonFlex}>
+          <Button
+            title="Save"
+            onPress={handleSave}
+            disabled={saving}
+            color={palette.accent}
+          />
         </View>
       </View>
     </ScrollView>
   );
 }
+
+const styles = StyleSheet.create({
+  loadingState: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: palette.background,
+  },
+  screen: {
+    flex: 1,
+    backgroundColor: palette.background,
+  },
+  content: {
+    padding: 20,
+    gap: 20,
+    paddingBottom: 32,
+  },
+  card: {
+    backgroundColor: palette.surface,
+    borderRadius: 22,
+    padding: 20,
+    gap: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: palette.border,
+    ...cardShadow(16),
+  },
+  pageTitle: {
+    fontSize: 24,
+    fontWeight: "700",
+    color: palette.primaryText,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: palette.primaryText,
+  },
+  sectionSubtitle: {
+    fontSize: 14,
+    color: palette.secondaryText,
+    lineHeight: 20,
+  },
+  fieldGroup: {
+    gap: 8,
+  },
+  fieldLabel: {
+    fontWeight: "600",
+    color: palette.primaryText,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: palette.border,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+    color: palette.primaryText,
+    backgroundColor: palette.surfaceSubtle,
+  },
+  textArea: {
+    borderWidth: 1,
+    borderColor: palette.border,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    fontSize: 16,
+    color: palette.primaryText,
+    minHeight: 100,
+    textAlignVertical: "top",
+    backgroundColor: palette.surfaceSubtle,
+  },
+  inlineButtons: {
+    flexDirection: "row",
+    gap: 12,
+  },
+  buttonFlex: {
+    flex: 1,
+  },
+  photoCard: {
+    gap: 12,
+    backgroundColor: palette.surfaceSubtle,
+    padding: 14,
+    borderRadius: 18,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: palette.border,
+    ...cardShadow(8),
+  },
+  photoImage: {
+    width: "100%",
+    height: 180,
+    borderRadius: 12,
+  },
+  photoPlaceholder: {
+    height: 180,
+    borderRadius: 12,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#e2e8f0",
+    paddingHorizontal: 12,
+  },
+  photoPlaceholderText: {
+    textAlign: "center",
+    color: palette.secondaryText,
+  },
+  emptyCard: {
+    padding: 18,
+    borderRadius: 16,
+    alignItems: "center",
+    borderWidth: StyleSheet.hairlineWidth,
+    borderStyle: "dashed",
+    borderColor: palette.border,
+    backgroundColor: palette.surfaceSubtle,
+  },
+  emptyText: {
+    color: palette.mutedText,
+  },
+  itemSeparator: {
+    height: 12,
+  },
+  itemCard: {
+    backgroundColor: palette.surfaceSubtle,
+    borderRadius: 16,
+    padding: 16,
+    gap: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: palette.border,
+    ...cardShadow(6),
+  },
+  itemInfo: {
+    gap: 4,
+  },
+  itemTitle: {
+    fontWeight: "600",
+    color: palette.primaryText,
+  },
+  itemMeta: {
+    color: palette.secondaryText,
+  },
+  inputRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  inputGrow: {
+    flex: 1,
+  },
+  prefixSymbol: {
+    fontWeight: "700",
+    color: palette.primaryText,
+  },
+  suffixSymbol: {
+    fontWeight: "700",
+    color: palette.primaryText,
+  },
+  helpText: {
+    fontSize: 12,
+    color: palette.secondaryText,
+  },
+  pickerShell: {
+    borderWidth: 1,
+    borderColor: palette.border,
+    borderRadius: 12,
+    overflow: "hidden",
+    backgroundColor: palette.surfaceSubtle,
+  },
+  totalsCard: {
+    gap: 10,
+  },
+  totalsRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  totalsLabel: {
+    color: palette.secondaryText,
+  },
+  totalsValue: {
+    fontWeight: "600",
+    color: palette.primaryText,
+  },
+  totalsGrand: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: palette.primaryText,
+  },
+  footerButtons: {
+    flexDirection: "row",
+    gap: 12,
+    paddingBottom: 16,
+  },
+});

--- a/app/(tabs)/estimates/index.tsx
+++ b/app/(tabs)/estimates/index.tsx
@@ -5,6 +5,7 @@ import {
   Alert,
   FlatList,
   Pressable,
+  StyleSheet,
   Text,
   View,
   Button,
@@ -12,6 +13,7 @@ import {
 import { openDB, queueChange } from "../../../lib/sqlite";
 import { sanitizeEstimateForQueue } from "../../../lib/estimates";
 import { runSync } from "../../../lib/sync";
+import { cardShadow, palette } from "../../../lib/theme";
 
 export type EstimateListItem = {
   id: string;
@@ -176,49 +178,42 @@ export default function EstimatesScreen() {
 
   const renderEstimate = useCallback(
     ({ item }: { item: EstimateListItem }) => (
-      <View
-        style={{
-          padding: 16,
-          borderWidth: 1,
-          borderRadius: 10,
-          marginBottom: 12,
-          backgroundColor: "#fff",
-          gap: 8,
-        }}
-      >
-        <Pressable onPress={() => router.push(`/(tabs)/estimates/${item.id}`)}>
-          <Text style={{ fontSize: 18, fontWeight: "600" }}>
+      <View style={styles.card}>
+        <Pressable
+          onPress={() => router.push(`/(tabs)/estimates/${item.id}`)}
+          style={styles.cardBody}
+        >
+          <Text style={styles.cardTitle}>
             {item.customer_name ?? "Unknown customer"}
           </Text>
-          <Text style={{ color: "#555", marginTop: 4 }}>
-            Status: {formatStatus(item.status)}
-          </Text>
-          <Text style={{ color: "#555", marginTop: 2 }}>
+          <Text style={styles.cardMeta}>Status: {formatStatus(item.status)}</Text>
+          <Text style={styles.cardMeta}>
             Total: {formatCurrency(item.total)}
           </Text>
-          <Text style={{ color: "#555", marginTop: 2 }}>
+          <Text style={styles.cardMeta}>
             Labor: {formatCurrency(item.labor_total ?? 0)}
           </Text>
-          <Text style={{ color: "#555", marginTop: 2 }}>
+          <Text style={styles.cardMeta}>
             Materials: {formatCurrency(item.material_total ?? 0)}
           </Text>
           {item.date ? (
-            <Text style={{ color: "#777", marginTop: 2 }}>
+            <Text style={styles.cardMeta}>
               Date: {new Date(item.date).toLocaleDateString()}
             </Text>
           ) : null}
         </Pressable>
-        <View style={{ flexDirection: "row", gap: 12 }}>
-          <View style={{ flex: 1 }}>
+        <View style={styles.buttonRow}>
+          <View style={styles.buttonFlex}>
             <Button
               title="Edit"
+              color={palette.accent}
               onPress={() => router.push(`/(tabs)/estimates/${item.id}`)}
             />
           </View>
-          <View style={{ flex: 1 }}>
+          <View style={styles.buttonFlex}>
             <Button
               title="Delete"
-              color="#b00020"
+              color={palette.danger}
               onPress={() => handleDelete(item)}
             />
           </View>
@@ -230,15 +225,19 @@ export default function EstimatesScreen() {
 
   const listHeader = useMemo(
     () => (
-      <View style={{ gap: 12, marginBottom: 16 }}>
-        <Text style={{ fontSize: 24, fontWeight: "700" }}>Estimates</Text>
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Estimates</Text>
+        <Text style={styles.headerSubtitle}>
+          Review drafts, monitor status changes, and keep your pipeline fresh.
+        </Text>
         <Button
           title="Create Estimate"
+          color={palette.accent}
           onPress={() => router.push("/(tabs)/estimates/new")}
         />
         {loading ? (
-          <View style={{ paddingVertical: 20 }}>
-            <ActivityIndicator />
+          <View style={styles.loadingRow}>
+            <ActivityIndicator color={palette.accent} />
           </View>
         ) : null}
       </View>
@@ -247,17 +246,17 @@ export default function EstimatesScreen() {
   );
 
   return (
-    <View style={{ flex: 1, padding: 16, backgroundColor: "#f5f5f5" }}>
+    <View style={styles.screen}>
       <FlatList
         data={estimates}
         keyExtractor={(item) => item.id}
         renderItem={renderEstimate}
-        contentContainerStyle={{ paddingBottom: 24 }}
+        contentContainerStyle={styles.listContent}
         ListHeaderComponent={listHeader}
         ListEmptyComponent={
           !loading ? (
-            <View style={{ paddingVertical: 40 }}>
-              <Text style={{ textAlign: "center", color: "#666" }}>
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyText}>
                 No estimates found.
               </Text>
             </View>
@@ -269,3 +268,67 @@ export default function EstimatesScreen() {
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+    backgroundColor: palette.background,
+  },
+  header: {
+    gap: 12,
+    marginBottom: 12,
+  },
+  headerTitle: {
+    fontSize: 28,
+    fontWeight: "700",
+    color: palette.primaryText,
+  },
+  headerSubtitle: {
+    fontSize: 14,
+    color: palette.secondaryText,
+    lineHeight: 20,
+  },
+  loadingRow: {
+    paddingVertical: 16,
+  },
+  listContent: {
+    paddingBottom: 32,
+    gap: 16,
+  },
+  card: {
+    backgroundColor: palette.surface,
+    borderRadius: 18,
+    padding: 18,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: palette.border,
+    gap: 12,
+    ...cardShadow(12),
+  },
+  cardBody: {
+    gap: 6,
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: palette.primaryText,
+  },
+  cardMeta: {
+    color: palette.secondaryText,
+  },
+  buttonRow: {
+    flexDirection: "row",
+    gap: 12,
+  },
+  buttonFlex: {
+    flex: 1,
+  },
+  emptyState: {
+    paddingVertical: 48,
+    alignItems: "center",
+  },
+  emptyText: {
+    color: palette.mutedText,
+  },
+});

--- a/app/(tabs)/estimates/item-editor.tsx
+++ b/app/(tabs)/estimates/item-editor.tsx
@@ -1,8 +1,45 @@
 import React, { useCallback, useEffect, useRef } from "react";
 import { useNavigation, useRouter } from "expo-router";
-import { ActivityIndicator, ScrollView, Text, View } from "react-native";
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
 import EstimateItemForm from "../../../components/EstimateItemForm";
 import { useItemEditor } from "../../../context/ItemEditorContext";
+import { palette, cardShadow } from "../../../lib/theme";
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: palette.surface,
+  },
+  screen: {
+    flex: 1,
+    backgroundColor: palette.background,
+  },
+  content: {
+    padding: 20,
+  },
+  card: {
+    backgroundColor: palette.surface,
+    borderRadius: 18,
+    padding: 20,
+    gap: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: palette.border,
+    ...cardShadow(10),
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: palette.primaryText,
+  },
+});
 
 export default function EstimateItemEditorScreen() {
   const router = useRouter();
@@ -67,33 +104,30 @@ export default function EstimateItemEditorScreen() {
 
   if (!config) {
     return (
-      <View
-        style={{
-          flex: 1,
-          alignItems: "center",
-          justifyContent: "center",
-          backgroundColor: "#fff",
-        }}
-      >
-        <ActivityIndicator size="large" color="#0F172A" />
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color={palette.accent} />
       </View>
     );
   }
 
+  const templates =
+    typeof config.templates === "function"
+      ? config.templates()
+      : config.templates;
+
   return (
-    <ScrollView
-      contentContainerStyle={{ padding: 16, gap: 16 }}
-      style={{ flex: 1, backgroundColor: "#fff" }}
-    >
-      <Text style={{ fontSize: 20, fontWeight: "600" }}>{config.title}</Text>
-      <EstimateItemForm
-        initialValue={config.initialValue}
-        initialTemplateId={config.initialTemplateId ?? null}
-        templates={config.templates}
-        onSubmit={handleSubmit}
-        onCancel={handleCancel}
-        submitLabel={config.submitLabel}
-      />
+    <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
+      <View style={styles.card}>
+        <Text style={styles.title}>{config.title}</Text>
+        <EstimateItemForm
+          initialValue={config.initialValue}
+          initialTemplateId={config.initialTemplateId ?? null}
+          templates={templates}
+          onSubmit={handleSubmit}
+          onCancel={handleCancel}
+          submitLabel={config.submitLabel}
+        />
+      </View>
     </ScrollView>
   );
 }

--- a/components/CustomerForm.tsx
+++ b/components/CustomerForm.tsx
@@ -1,11 +1,12 @@
 // components/CustomerForm.tsx
 import React, { useState } from "react";
-import { View, TextInput, Button, Alert } from "react-native";
+import { View, TextInput, Button, Alert, StyleSheet } from "react-native";
 import "react-native-get-random-values";
 import { v4 as uuidv4 } from "uuid";
 import { openDB, queueChange } from "../lib/sqlite";
 import { runSync } from "../lib/sync";
 import { useAuth } from "../context/AuthContext";
+import { palette, cardShadow } from "../lib/theme";
 
 type Props = {
   onSaved?: (customer: { id: string; name: string }) => void;
@@ -84,49 +85,78 @@ export default function CustomerForm({ onSaved, onCancel }: Props) {
   }
 
   return (
-    <View style={{ gap: 8 }}>
+    <View style={styles.container}>
       <TextInput
         placeholder="Name"
+        placeholderTextColor={palette.mutedText}
         value={name}
         onChangeText={setName}
-        style={{ borderWidth: 1, padding: 10, borderRadius: 8 }}
+        style={styles.input}
       />
       <TextInput
         placeholder="Phone"
+        placeholderTextColor={palette.mutedText}
         value={phone}
         onChangeText={setPhone}
-        style={{ borderWidth: 1, padding: 10, borderRadius: 8 }}
+        style={styles.input}
       />
       <TextInput
         placeholder="Email"
+        placeholderTextColor={palette.mutedText}
         value={email}
         onChangeText={setEmail}
         autoCapitalize="none"
         keyboardType="email-address"
-        style={{ borderWidth: 1, padding: 10, borderRadius: 8 }}
+        style={styles.input}
       />
       <TextInput
         placeholder="Address"
+        placeholderTextColor={palette.mutedText}
         value={address}
         onChangeText={setAddress}
-        style={{ borderWidth: 1, padding: 10, borderRadius: 8 }}
+        style={styles.input}
       />
       <TextInput
         placeholder="Account notes"
+        placeholderTextColor={palette.mutedText}
         value={notes}
         onChangeText={setNotes}
         multiline
         numberOfLines={3}
-        style={{
-          borderWidth: 1,
-          padding: 10,
-          borderRadius: 8,
-          textAlignVertical: "top",
-          minHeight: 90,
-        }}
+        style={styles.textArea}
       />
-      <Button title="Save Customer" onPress={saveCustomer} />
-      {onCancel ? <Button title="Cancel" onPress={onCancel} /> : null}
+      <Button title="Save Customer" onPress={saveCustomer} color={palette.accent} />
+      {onCancel ? (
+        <Button title="Cancel" onPress={onCancel} color={palette.secondaryText} />
+      ) : null}
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 10,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: palette.border,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: palette.surface,
+    color: palette.primaryText,
+    ...cardShadow(4),
+  },
+  textArea: {
+    borderWidth: 1,
+    borderColor: palette.border,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    backgroundColor: palette.surface,
+    color: palette.primaryText,
+    minHeight: 90,
+    textAlignVertical: "top",
+    ...cardShadow(4),
+  },
+});

--- a/components/EstimateItemForm.tsx
+++ b/components/EstimateItemForm.tsx
@@ -1,6 +1,15 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Alert, Button, Switch, Text, TextInput, View } from "react-native";
+import {
+  Alert,
+  Button,
+  Switch,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
 import { Picker } from "@react-native-picker/picker";
+import { palette } from "../lib/theme";
 
 export type EstimateItemFormValues = {
   description: string;
@@ -58,6 +67,66 @@ function formatCurrency(value: number): string {
     minimumFractionDigits: 2,
   }).format(value);
 }
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 16,
+  },
+  fieldGroup: {
+    gap: 6,
+  },
+  label: {
+    fontWeight: "600",
+    color: palette.primaryText,
+  },
+  pickerContainer: {
+    borderWidth: 1,
+    borderColor: palette.border,
+    borderRadius: 12,
+    overflow: "hidden",
+    backgroundColor: palette.surfaceSubtle,
+  },
+  textInput: {
+    borderWidth: 1,
+    borderColor: palette.border,
+    borderRadius: 12,
+    padding: 12,
+    fontSize: 16,
+    color: palette.primaryText,
+    backgroundColor: palette.surfaceSubtle,
+  },
+  totalValue: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: palette.primaryText,
+  },
+  switchRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  switchText: {
+    flex: 1,
+    gap: 4,
+  },
+  switchLabel: {
+    fontWeight: "600",
+    color: palette.primaryText,
+  },
+  switchHint: {
+    color: palette.mutedText,
+    fontSize: 12,
+    lineHeight: 16,
+  },
+  actionRow: {
+    flexDirection: "row",
+    gap: 12,
+  },
+  actionFlex: {
+    flex: 1,
+  },
+});
 
 export default function EstimateItemForm({
   initialValue,
@@ -161,11 +230,11 @@ export default function EstimateItemForm({
   };
 
   return (
-    <View style={{ gap: 12 }}>
+    <View style={styles.container}>
       {templates.length > 0 ? (
-        <View style={{ gap: 6 }}>
-          <Text style={{ fontWeight: "600" }}>Saved items</Text>
-          <View style={{ borderWidth: 1, borderRadius: 8 }}>
+        <View style={styles.fieldGroup}>
+          <Text style={styles.label}>Saved items</Text>
+          <View style={styles.pickerContainer}>
             <Picker
               selectedValue={selectedTemplateId ?? ""}
               onValueChange={(value) => {
@@ -189,66 +258,77 @@ export default function EstimateItemForm({
         </View>
       ) : null}
 
-      <View style={{ gap: 6 }}>
-        <Text style={{ fontWeight: "600" }}>Description</Text>
+      <View style={styles.fieldGroup}>
+        <Text style={styles.label}>Description</Text>
         <TextInput
           placeholder="Item description"
           value={description}
           onChangeText={setDescription}
-          style={{ borderWidth: 1, borderRadius: 8, padding: 10 }}
+          placeholderTextColor={palette.mutedText}
+          style={styles.textInput}
         />
       </View>
 
-      <View style={{ gap: 6 }}>
-        <Text style={{ fontWeight: "600" }}>Quantity</Text>
+      <View style={styles.fieldGroup}>
+        <Text style={styles.label}>Quantity</Text>
         <TextInput
           placeholder="0"
           value={quantityText}
           onChangeText={setQuantityText}
           keyboardType="numeric"
-          style={{ borderWidth: 1, borderRadius: 8, padding: 10 }}
+          placeholderTextColor={palette.mutedText}
+          style={styles.textInput}
         />
       </View>
 
-      <View style={{ gap: 6 }}>
-        <Text style={{ fontWeight: "600" }}>Unit Price</Text>
+      <View style={styles.fieldGroup}>
+        <Text style={styles.label}>Unit Price</Text>
         <TextInput
           placeholder="0.00"
           value={unitPriceText}
           onChangeText={setUnitPriceText}
           keyboardType="decimal-pad"
-          style={{ borderWidth: 1, borderRadius: 8, padding: 10 }}
+          placeholderTextColor={palette.mutedText}
+          style={styles.textInput}
         />
       </View>
 
-      <View style={{ gap: 6 }}>
-        <Text style={{ fontWeight: "600" }}>Line Total</Text>
-        <Text>{formatCurrency(total)}</Text>
+      <View style={styles.fieldGroup}>
+        <Text style={styles.label}>Line Total</Text>
+        <Text style={styles.totalValue}>{formatCurrency(total)}</Text>
       </View>
 
-      <View
-        style={{
-          flexDirection: "row",
-          alignItems: "center",
-          justifyContent: "space-between",
-          paddingVertical: 4,
-        }}
-      >
-        <View style={{ flex: 1, paddingRight: 12 }}>
-          <Text style={{ fontWeight: "600" }}>Save for future use</Text>
-          <Text style={{ color: "#555", marginTop: 2, fontSize: 12 }}>
+      <View style={styles.switchRow}>
+        <View style={styles.switchText}>
+          <Text style={styles.switchLabel}>Save for future use</Text>
+          <Text style={styles.switchHint}>
             Adds this item to your library so you can quickly reuse or update it later.
           </Text>
         </View>
-        <Switch value={saveToLibrary} onValueChange={setSaveToLibrary} />
+        <Switch
+          value={saveToLibrary}
+          onValueChange={setSaveToLibrary}
+          trackColor={{ true: palette.accentMuted, false: palette.border }}
+          thumbColor={saveToLibrary ? palette.surface : undefined}
+        />
       </View>
 
-      <View style={{ flexDirection: "row", gap: 12 }}>
-        <View style={{ flex: 1 }}>
-          <Button title="Cancel" onPress={onCancel} disabled={submitting} />
+      <View style={styles.actionRow}>
+        <View style={styles.actionFlex}>
+          <Button
+            title="Cancel"
+            onPress={onCancel}
+            disabled={submitting}
+            color={palette.secondaryText}
+          />
         </View>
-        <View style={{ flex: 1 }}>
-          <Button title={submitLabel} onPress={handleSubmit} disabled={submitting} />
+        <View style={styles.actionFlex}>
+          <Button
+            title={submitLabel}
+            onPress={handleSubmit}
+            disabled={submitting}
+            color={palette.accent}
+          />
         </View>
       </View>
     </View>

--- a/context/ItemEditorContext.tsx
+++ b/context/ItemEditorContext.tsx
@@ -20,7 +20,7 @@ export type ItemEditorConfig = {
     unit_price: number;
   };
   initialTemplateId?: string | null;
-  templates?: EstimateItemTemplate[];
+  templates?: EstimateItemTemplate[] | (() => EstimateItemTemplate[]);
   onSubmit: (payload: EstimateItemFormSubmit) => Promise<void> | void;
   onCancel?: () => void;
 };

--- a/lib/pdf.ts
+++ b/lib/pdf.ts
@@ -266,7 +266,19 @@ export async function renderEstimatePdf(
   options: EstimatePdfOptions
 ): Promise<EstimatePdfResult> {
   if (Platform.OS === "web") {
-    throw new Error("PDF generation is only supported on native platforms.");
+    const html = await createHtml(options);
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const fileName = `estimate-${options.estimate.id}-${timestamp}.html`;
+
+    if (typeof Blob !== "undefined" && typeof URL !== "undefined") {
+      const blob = new Blob([html], { type: "text/html" });
+      const uri = URL.createObjectURL(blob);
+      return { uri, html, fileName };
+    }
+
+    const base64 = btoa(unescape(encodeURIComponent(html)));
+    const uri = `data:text/html;base64,${base64}`;
+    return { uri, html, fileName };
   }
 
   const html = await createHtml(options);

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,0 +1,51 @@
+import { Platform } from "react-native";
+
+export const palette = {
+  background: "#f1f5f9",
+  surface: "#ffffff",
+  surfaceSubtle: "#f8fafc",
+  border: "#d0d7e6",
+  primaryText: "#0f172a",
+  secondaryText: "#475569",
+  mutedText: "#64748b",
+  accent: "#2563eb",
+  accentMuted: "#1d4ed8",
+  danger: "#dc2626",
+  success: "#16a34a",
+};
+
+export function cardShadow(depth: number = 12) {
+  if (Platform.OS === "web") {
+    return {};
+  }
+
+  const opacity = depth >= 16 ? 0.18 : 0.12;
+  const height = Math.max(4, Math.round(depth / 3));
+  const radius = Math.max(8, Math.round(depth / 2));
+
+  return {
+    shadowColor: "rgba(15, 23, 42, 0.35)",
+    shadowOpacity: opacity,
+    shadowRadius: radius,
+    shadowOffset: { width: 0, height: height },
+    elevation: Math.max(4, Math.round(depth / 4)),
+  } as const;
+}
+
+export const textVariants = {
+  title: {
+    fontSize: 20,
+    fontWeight: "700" as const,
+    color: palette.primaryText,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: palette.secondaryText,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: "600" as const,
+    color: palette.secondaryText,
+    textTransform: "uppercase" as const,
+  },
+};


### PR DESCRIPTION
## Summary
- introduce a reusable theme palette and apply higher-contrast styling across estimate and customer flows
- fix saved item loading in the editor by allowing templates to be provided lazily and refresh the item editor UI
- enable PDF preview/email/SMS on web, auto-mark estimates as sent after delivery, and update associated tests

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dc0dc958dc8323a248bd73e72a1277