### PR TITLE
Fix app crash by adding SafeAreaProvider

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,6 +8,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 import { AuthProvider, useAuth } from "../context/AuthContext";
 import { SettingsProvider } from "../context/SettingsContext";
 import { initLocalDB } from "../lib/sqlite";
@@ -106,11 +107,13 @@ export default function RootLayout() {
   }, []);
 
   return (
-    <SettingsProvider>
-      <AuthProvider>
-        <RootNavigator />
-      </AuthProvider>
-    </SettingsProvider>
+    <SafeAreaProvider>
+      <SettingsProvider>
+        <AuthProvider>
+          <RootNavigator />
+        </AuthProvider>
+      </SettingsProvider>
+    </SafeAreaProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
- wrap the root layout with SafeAreaProvider so tab layouts using safe-area hooks have context

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dc2bfda31483239eea74ef44d49d07