### PR TITLE
feat: scaffold shared ui components

### DIFF
--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -1,85 +1,41 @@
-import { PropsWithChildren, ReactNode, useMemo } from "react";
+import { PropsWithChildren, useMemo } from "react";
 import { StyleProp, StyleSheet, Text, TextStyle, View, ViewStyle } from "react-native";
-import { useTheme } from "../../lib/theme";
+import { useTheme } from "../../theme";
 
 export type BadgeTone = "info" | "warning" | "success" | "danger" | "muted";
 
 export interface BadgeProps {
-  children: ReactNode;
   tone?: BadgeTone;
   style?: StyleProp<ViewStyle>;
   textStyle?: StyleProp<TextStyle>;
-  icon?: ReactNode;
 }
 
-export function Badge({
-  children,
-  tone = "warning",
-  style,
-  textStyle,
-  icon,
-}: PropsWithChildren<BadgeProps>) {
-  const theme = useTheme();
+export function Badge({ children, style, textStyle }: PropsWithChildren<BadgeProps>) {
+  const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   return (
-    <View style={[styles.base, styles[tone], style]}>
-      {icon ? <View style={styles.icon}>{icon}</View> : null}
-      <Text style={[styles.label, styles[`${tone}Text` as const], textStyle]}>{children}</Text>
+    <View style={[styles.container, style]}>
+      <Text style={[styles.label, textStyle]}>{children}</Text>
     </View>
   );
 }
 
-function createStyles(theme: ReturnType<typeof useTheme>) {
+function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
   return StyleSheet.create({
-    base: {
-      flexDirection: "row",
-      alignItems: "center",
+    container: {
       alignSelf: "flex-start",
-      paddingHorizontal: 12,
-      paddingVertical: 6,
-      borderRadius: 999,
-      gap: 6,
+      backgroundColor: theme.colors.highlight,
+      borderRadius: theme.radii.full,
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: theme.spacing.xs,
     },
     label: {
       fontSize: 13,
       fontWeight: "600",
-      letterSpacing: 0.3,
+      letterSpacing: 0.4,
+      color: theme.colors.primaryText,
       textTransform: "uppercase",
-    },
-    icon: {
-      alignItems: "center",
-      justifyContent: "center",
-    },
-    warning: {
-      backgroundColor: theme.highlight,
-    },
-    warningText: {
-      color: theme.primaryText,
-    },
-    info: {
-      backgroundColor: theme.accentMuted,
-    },
-    infoText: {
-      color: theme.surface,
-    },
-    success: {
-      backgroundColor: theme.successSurface,
-    },
-    successText: {
-      color: theme.success,
-    },
-    danger: {
-      backgroundColor: theme.dangerSurface,
-    },
-    dangerText: {
-      color: theme.danger,
-    },
-    muted: {
-      backgroundColor: theme.surfaceSubtle,
-    },
-    mutedText: {
-      color: theme.secondaryText,
     },
   });
 }

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,10 +1,19 @@
-import { ActivityIndicator, Pressable, StyleProp, StyleSheet, Text, TextStyle, View, ViewStyle } from "react-native";
-import { ReactNode, useMemo } from "react";
-import { useTheme } from "../../lib/theme";
+import { useMemo, type ReactNode } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleProp,
+  StyleSheet,
+  Text,
+  TextStyle,
+  View,
+  ViewStyle,
+} from "react-native";
+import { useTheme } from "../../theme";
 
 export type ButtonVariant = "primary" | "secondary" | "ghost";
 
-type ButtonSize = "default" | "small";
+type ButtonAlignment = "inline" | "full";
 
 export interface ButtonProps {
   label: string;
@@ -12,12 +21,12 @@ export interface ButtonProps {
   disabled?: boolean;
   loading?: boolean;
   variant?: ButtonVariant;
-  icon?: ReactNode;
+  alignment?: ButtonAlignment;
+  leadingIcon?: ReactNode;
   trailingIcon?: ReactNode;
   style?: StyleProp<ViewStyle>;
-  contentStyle?: StyleProp<ViewStyle>;
   textStyle?: StyleProp<TextStyle>;
-  size?: ButtonSize;
+  contentStyle?: StyleProp<ViewStyle>;
   accessibilityLabel?: string;
 }
 
@@ -27,52 +36,42 @@ export function Button({
   disabled = false,
   loading = false,
   variant = "primary",
-  icon,
+  alignment = "full",
+  leadingIcon,
   trailingIcon,
   style,
-  contentStyle,
   textStyle,
-  size = "default",
+  contentStyle,
   accessibilityLabel,
 }: ButtonProps) {
-  const theme = useTheme();
-
+  const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
-  const sizeStyles = size === "small" ? styles.small : styles.default;
   const isDisabled = disabled || loading;
 
   return (
     <Pressable
-      accessibilityRole="button"
       accessibilityLabel={accessibilityLabel ?? label}
+      accessibilityRole="button"
       accessibilityState={{ disabled: isDisabled, busy: loading }}
       disabled={isDisabled}
       onPress={onPress}
       style={({ pressed }) => [
         styles.base,
         styles[variant],
-        sizeStyles,
+        alignment === "full" ? styles.fullWidth : null,
         pressed && !isDisabled ? styles.pressed : null,
-        isDisabled ? styles.disabled : null,
         style,
       ]}
     >
-      <View style={[styles.content, sizeStyles, contentStyle]}>
+      <View style={[styles.content, contentStyle]}>
         {loading ? (
-          <ActivityIndicator color={variant === "secondary" ? theme.accent : theme.surface} />
+          <ActivityIndicator
+            color={variant === "primary" ? theme.colors.surface : theme.colors.primary}
+          />
         ) : (
           <>
-            {icon ? <View style={styles.icon}>{icon}</View> : null}
-            <Text
-              style={[
-                styles.label,
-                styles[`${variant}Text` as const],
-                size === "small" ? styles.smallText : null,
-                textStyle,
-              ]}
-            >
-              {label}
-            </Text>
+            {leadingIcon ? <View style={styles.icon}>{leadingIcon}</View> : null}
+            <Text style={[styles.label, styles[`${variant}Label`], textStyle]}>{label}</Text>
             {trailingIcon ? <View style={styles.icon}>{trailingIcon}</View> : null}
           </>
         )}
@@ -81,24 +80,20 @@ export function Button({
   );
 }
 
-function createStyles(theme: ReturnType<typeof useTheme>) {
+function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
   return StyleSheet.create({
     base: {
-      borderRadius: 16,
+      borderRadius: theme.radii.lg,
       overflow: "hidden",
-    },
-    default: {
-      minHeight: 56,
-    },
-    small: {
-      minHeight: 44,
+      minHeight: 48,
     },
     content: {
       flexDirection: "row",
       alignItems: "center",
       justifyContent: "center",
-      paddingHorizontal: 20,
-      gap: 10,
+      paddingVertical: theme.spacing.sm,
+      paddingHorizontal: theme.spacing.xl,
+      gap: theme.spacing.sm,
     },
     icon: {
       alignItems: "center",
@@ -109,34 +104,32 @@ function createStyles(theme: ReturnType<typeof useTheme>) {
       fontWeight: "600",
       letterSpacing: 0.2,
     },
-    smallText: {
-      fontSize: 14,
-    },
     primary: {
-      backgroundColor: theme.accent,
+      backgroundColor: theme.colors.primary,
     },
-    primaryText: {
-      color: theme.surface,
+    primaryLabel: {
+      color: theme.colors.surface,
     },
     secondary: {
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: theme.colors.primary,
       backgroundColor: "transparent",
-      borderWidth: 1,
-      borderColor: theme.accent,
     },
-    secondaryText: {
-      color: theme.accent,
+    secondaryLabel: {
+      color: theme.colors.primary,
     },
     ghost: {
       backgroundColor: "transparent",
     },
-    ghostText: {
-      color: theme.primaryText,
+    ghostLabel: {
+      color: theme.colors.primary,
+    },
+    fullWidth: {
+      alignSelf: "stretch",
+      width: "100%",
     },
     pressed: {
-      opacity: 0.85,
-    },
-    disabled: {
-      opacity: 0.6,
+      opacity: 0.9,
     },
   });
 }

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,36 +1,42 @@
-import { PropsWithChildren, ReactNode, useMemo } from "react";
-import { StyleProp, StyleSheet, View, ViewStyle } from "react-native";
-import { cardShadow, useTheme } from "../../lib/theme";
+import { PropsWithChildren, useMemo } from "react";
+import { Platform, StyleProp, StyleSheet, View, ViewStyle } from "react-native";
+import { useTheme } from "../../theme";
 
 export interface CardProps {
-  children: ReactNode;
   style?: StyleProp<ViewStyle>;
   elevated?: boolean;
-  padding?: number;
 }
 
-export function Card({
-  children,
-  style,
-  elevated = true,
-  padding = 20,
-}: PropsWithChildren<CardProps>) {
-  const theme = useTheme();
-  const styles = useMemo(() => createStyles(theme, padding, elevated), [theme, padding, elevated]);
+export function Card({ children, style, elevated = true }: PropsWithChildren<CardProps>) {
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme, elevated), [theme, elevated]);
 
   return <View style={[styles.container, style]}>{children}</View>;
 }
 
-function createStyles(theme: ReturnType<typeof useTheme>, padding: number, elevated: boolean) {
+function createStyles(
+  theme: ReturnType<typeof useTheme>["theme"],
+  elevated: boolean,
+) {
+  const shadow: ViewStyle = elevated
+    ? {
+        shadowColor: theme.colors.overlay,
+        shadowOpacity: Platform.OS === "ios" ? 0.18 : 0.12,
+        shadowRadius: theme.spacing.xl,
+        shadowOffset: { width: 0, height: theme.spacing.xs },
+        elevation: 6,
+      }
+    : {};
+
   return StyleSheet.create({
     container: {
-      backgroundColor: theme.surface,
-      borderRadius: 16,
-      padding,
+      backgroundColor: theme.colors.surface,
+      borderRadius: theme.radii.lg,
+      padding: theme.spacing.xl,
       borderWidth: StyleSheet.hairlineWidth,
-      borderColor: theme.border,
-      gap: 16,
-      ...(elevated ? cardShadow(14, theme.mode) : {}),
+      borderColor: theme.colors.border,
+      gap: theme.spacing.lg,
+      ...shadow,
     },
   });
 }

--- a/components/ui/FAB.tsx
+++ b/components/ui/FAB.tsx
@@ -1,0 +1,74 @@
+import { useMemo, type ReactNode } from "react";
+import { Platform, Pressable, StyleProp, StyleSheet, ViewStyle } from "react-native";
+import { useTheme } from "../../theme";
+
+type FABPalette = "auto" | "primary" | "highlight";
+
+export interface FABProps {
+  icon: ReactNode;
+  onPress?: () => void;
+  accessibilityLabel: string;
+  palette?: FABPalette;
+  style?: StyleProp<ViewStyle>;
+}
+
+export function FAB({
+  icon,
+  onPress,
+  accessibilityLabel,
+  palette = "auto",
+  style,
+}: FABProps) {
+  const { theme, mode } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const resolvedPalette = palette === "auto" ? (mode === "dark" ? "highlight" : "primary") : palette;
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.base,
+        styles[resolvedPalette],
+        pressed ? styles.pressed : null,
+        style,
+      ]}
+    >
+      {icon}
+    </Pressable>
+  );
+}
+
+function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
+  return StyleSheet.create({
+    base: {
+      alignItems: "center",
+      justifyContent: "center",
+      borderRadius: theme.radii.full,
+      padding: theme.spacing.lg,
+      ...Platform.select({
+        ios: {
+          shadowColor: theme.colors.overlay,
+          shadowOpacity: 0.2,
+          shadowRadius: theme.spacing.lg,
+          shadowOffset: { width: 0, height: theme.spacing.xs },
+        },
+        default: {
+          elevation: 8,
+        },
+      }),
+    },
+    primary: {
+      backgroundColor: theme.colors.primary,
+    },
+    highlight: {
+      backgroundColor: theme.colors.highlight,
+    },
+    pressed: {
+      opacity: 0.9,
+    },
+  });
+}
+
+export default FAB;

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -17,7 +17,7 @@ import {
   View,
   ViewStyle,
 } from "react-native";
-import { useTheme } from "../../lib/theme";
+import { useTheme } from "../../theme";
 
 export interface InputProps extends TextInputProps {
   label?: string;
@@ -43,7 +43,7 @@ export const Input = forwardRef<TextInput, InputProps>(function Input(
   }: InputProps,
   ref: ForwardedRef<TextInput>,
 ) {
-  const theme = useTheme();
+  const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const [isFocused, setFocused] = useState(false);
 
@@ -86,7 +86,7 @@ export const Input = forwardRef<TextInput, InputProps>(function Input(
         {leftElement ? <View style={styles.adornment}>{leftElement}</View> : null}
         <TextInput
           ref={ref}
-          placeholderTextColor={theme.mutedText}
+          placeholderTextColor={theme.colors.textMuted}
           {...textInputProps}
           multiline={multiline}
           style={[styles.input, multiline ? styles.multilineInput : null, inputStyle]}
@@ -103,48 +103,48 @@ export const Input = forwardRef<TextInput, InputProps>(function Input(
   );
 });
 
-function createStyles(theme: ReturnType<typeof useTheme>) {
+function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
   return StyleSheet.create({
     container: {
-      gap: 6,
+      gap: theme.spacing.xs,
     },
     label: {
       fontSize: 14,
       fontWeight: "600",
-      color: theme.secondaryText,
+      color: theme.colors.textMuted,
     },
     fieldShell: {
       flexDirection: "row",
       alignItems: "center",
-      borderRadius: 16,
-      borderWidth: 1,
-      borderColor: theme.inputBorder,
-      backgroundColor: theme.inputBackground,
-      paddingHorizontal: 16,
-      minHeight: 52,
-      gap: 12,
+      borderRadius: theme.radii.lg,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: theme.colors.border,
+      backgroundColor: theme.colors.surface,
+      paddingHorizontal: theme.spacing.lg,
+      minHeight: theme.spacing.xxl + theme.spacing.lg,
+      gap: theme.spacing.sm,
     },
     multilineShell: {
       alignItems: "flex-start",
-      paddingVertical: 12,
+      paddingVertical: theme.spacing.sm,
     },
     input: {
       flex: 1,
       fontSize: 16,
-      color: theme.primaryText,
-      paddingVertical: 12,
+      color: theme.colors.text,
+      paddingVertical: theme.spacing.sm,
     },
     multilineInput: {
       textAlignVertical: "top",
-      minHeight: 100,
+      minHeight: theme.spacing.xxl * 3,
     },
     caption: {
       fontSize: 12,
-      color: theme.mutedText,
+      color: theme.colors.textMuted,
     },
     errorText: {
       fontSize: 12,
-      color: theme.danger,
+      color: theme.colors.danger,
     },
     adornment: {
       justifyContent: "center",
@@ -154,14 +154,14 @@ function createStyles(theme: ReturnType<typeof useTheme>) {
       marginLeft: "auto",
     },
     focusedState: {
-      borderColor: theme.accent,
-      shadowColor: theme.accent,
+      borderColor: theme.colors.primary,
+      shadowColor: theme.colors.primary,
       shadowOpacity: Platform.OS === "ios" ? 0.16 : 0,
-      shadowOffset: { width: 0, height: 6 },
-      shadowRadius: 12,
+      shadowOffset: { width: 0, height: theme.spacing.sm },
+      shadowRadius: theme.spacing.xl,
     },
     errorState: {
-      borderColor: theme.danger,
+      borderColor: theme.colors.danger,
     },
   });
 }

--- a/components/ui/ListItem.tsx
+++ b/components/ui/ListItem.tsx
@@ -1,0 +1,124 @@
+import { useMemo, type ReactNode } from "react";
+import {
+  Pressable,
+  StyleProp,
+  StyleSheet,
+  Text,
+  TextStyle,
+  View,
+  ViewStyle,
+} from "react-native";
+import { useTheme } from "../../theme";
+
+export interface ListItemProps {
+  title: string;
+  subtitle?: string;
+  amount?: string;
+  badge?: ReactNode;
+  onPress?: () => void;
+  style?: StyleProp<ViewStyle>;
+  titleStyle?: StyleProp<TextStyle>;
+  subtitleStyle?: StyleProp<TextStyle>;
+  amountStyle?: StyleProp<TextStyle>;
+}
+
+export function ListItem({
+  title,
+  subtitle,
+  amount,
+  badge,
+  onPress,
+  style,
+  titleStyle,
+  subtitleStyle,
+  amountStyle,
+}: ListItemProps) {
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  if (onPress) {
+    return (
+      <Pressable
+        accessibilityRole="button"
+        onPress={onPress}
+        style={({ pressed }) => [
+          styles.container,
+          pressed ? styles.pressed : null,
+          style,
+        ]}
+      >
+        <View style={styles.textColumn}>
+          <Text style={[styles.title, titleStyle]}>{title}</Text>
+          {subtitle ? (
+            <Text style={[styles.subtitle, subtitleStyle]}>{subtitle}</Text>
+          ) : null}
+        </View>
+        <View style={styles.rightColumn}>
+          {badge ? (
+            badge
+          ) : amount ? (
+            <Text style={[styles.amount, amountStyle]}>{amount}</Text>
+          ) : null}
+        </View>
+      </Pressable>
+    );
+  }
+
+  return (
+    <View style={[styles.container, style]}>
+      <View style={styles.textColumn}>
+        <Text style={[styles.title, titleStyle]}>{title}</Text>
+        {subtitle ? <Text style={[styles.subtitle, subtitleStyle]}>{subtitle}</Text> : null}
+      </View>
+      <View style={styles.rightColumn}>
+        {badge ? (
+          badge
+        ) : amount ? (
+          <Text style={[styles.amount, amountStyle]}>{amount}</Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
+  return StyleSheet.create({
+    container: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      paddingVertical: theme.spacing.lg,
+      paddingHorizontal: theme.spacing.xl,
+      backgroundColor: theme.colors.surface,
+      borderRadius: theme.radii.lg,
+      gap: theme.spacing.md,
+    },
+    pressed: {
+      opacity: 0.9,
+    },
+    textColumn: {
+      flex: 1,
+      gap: theme.spacing.xs,
+    },
+    rightColumn: {
+      marginLeft: theme.spacing.md,
+      alignItems: "flex-end",
+      justifyContent: "center",
+    },
+    title: {
+      fontSize: 16,
+      fontWeight: "600",
+      color: theme.colors.text,
+    },
+    subtitle: {
+      fontSize: 14,
+      color: theme.colors.textMuted,
+    },
+    amount: {
+      fontSize: 16,
+      fontWeight: "700",
+      color: theme.colors.primaryText,
+    },
+  });
+}
+
+export default ListItem;

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -6,3 +6,7 @@ export { Card } from "./Card";
 export type { CardProps } from "./Card";
 export { Input } from "./Input";
 export type { InputProps } from "./Input";
+export { ListItem } from "./ListItem";
+export type { ListItemProps } from "./ListItem";
+export { FAB } from "./FAB";
+export type { FABProps } from "./FAB";

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -37,6 +37,7 @@ export type ThemeColors = {
   textMuted: string;
   border: string;
   separator: string;
+  highlight: string;
   success: string;
   successSoft: string;
   warning: string;
@@ -88,6 +89,7 @@ export const light: Theme = {
     textMuted: "#5B667A",
     border: "#D3DBE8",
     separator: "#E4E8F0",
+    highlight: "#F5B700",
     success: "#2FBF71",
     successSoft: "#E3F7ED",
     warning: "#F59E0B",
@@ -113,6 +115,7 @@ export const dark: Theme = {
     textMuted: "#94A3B8",
     border: "#243049",
     separator: "#1D2740",
+    highlight: "#F5B700",
     success: "#3DD68C",
     successSoft: "#123D2C",
     warning: "#FBBF24",
@@ -132,9 +135,14 @@ type ThemeContextValue = {
   toggleMode: () => void;
 };
 
-export const ThemeContext = createContext<ThemeContextValue | undefined>(
-  undefined
-);
+const defaultThemeContext: ThemeContextValue = {
+  mode: "light",
+  theme: light,
+  setMode: () => {},
+  toggleMode: () => {},
+};
+
+export const ThemeContext = createContext<ThemeContextValue>(defaultThemeContext);
 
 export type ThemeProviderProps = {
   children: ReactNode;
@@ -162,11 +170,5 @@ export function ThemeProvider({
 }
 
 export function useTheme() {
-  const context = useContext(ThemeContext);
-
-  if (!context) {
-    throw new Error("useTheme must be used within a ThemeProvider");
-  }
-
-  return context;
+  return useContext(ThemeContext);
 }


### PR DESCRIPTION
## Summary
- scaffold reusable Button, Card, Badge, Input, ListItem, and FAB components that consume the theme provider
- extend the theme context with a highlight color and safe defaults for components rendered outside the provider

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68dd629346288323b0f2e8ec5dc27ace