### PR TITLE
Refactor auth screens to use shared UI components

### DIFF
--- a/app/(auth)/forgot-password.tsx
+++ b/app/(auth)/forgot-password.tsx
@@ -1,23 +1,18 @@
 import { Link } from "expo-router";
-import { useState } from "react";
-import {
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-  Pressable,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
+import { useMemo, useState } from "react";
+import { Alert, KeyboardAvoidingView, Platform, StyleSheet, View } from "react-native";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
+import { Body, Button, Card, Input, Subtitle, Title } from "../../components/ui";
+import { useTheme, type Theme } from "../../theme";
 
 const RESET_REDIRECT = process.env.EXPO_PUBLIC_SUPABASE_RESET_REDIRECT;
 
 export default function ForgotPasswordScreen() {
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
 
   const handleReset = async () => {
     if (!email) {
@@ -52,93 +47,64 @@ export default function ForgotPasswordScreen() {
       behavior={Platform.select({ ios: "padding", android: undefined })}
       style={styles.container}
     >
-      <View style={styles.card}>
+      <Card style={styles.card}>
         <View style={styles.logoContainer}>
           <BrandLogo size={80} />
         </View>
-        <Text style={styles.title}>Reset your password</Text>
-        <TextInput
+        <Title style={styles.title}>Reset your password</Title>
+        <Subtitle style={styles.subtitle}>
+          Enter the email linked to your account and we'll send reset instructions.
+        </Subtitle>
+        <Input
           autoCapitalize="none"
           autoComplete="email"
           autoCorrect={false}
           keyboardType="email-address"
-          placeholder="Email"
-          placeholderTextColor="#888"
-          style={styles.input}
+          placeholder="you@example.com"
+          label="Email"
           value={email}
           onChangeText={setEmail}
         />
-        <Pressable style={[styles.button, loading && styles.buttonDisabled]} onPress={handleReset} disabled={loading}>
-          <Text style={styles.buttonText}>{loading ? "Sending..." : "Send reset link"}</Text>
-        </Pressable>
+        <Button label="Send reset link" onPress={handleReset} loading={loading} />
         <View style={styles.linksRow}>
-          <Link href="/(auth)/login" style={styles.link}>
-            Back to sign in
+          <Link href="/(auth)/login">
+            <Body style={styles.link}>Back to sign in</Body>
           </Link>
         </View>
-      </View>
+      </Card>
     </KeyboardAvoidingView>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#0f172a",
-    justifyContent: "center",
-    paddingHorizontal: 24,
-  },
-  card: {
-    backgroundColor: "#fff",
-    borderRadius: 16,
-    padding: 24,
-    gap: 16,
-    shadowColor: "#000",
-    shadowOpacity: 0.15,
-    shadowOffset: { width: 0, height: 8 },
-    shadowRadius: 12,
-    elevation: 6,
-  },
-  logoContainer: {
-    alignItems: "center",
-    marginBottom: 4,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: "700",
-    color: "#0f172a",
-    textAlign: "center",
-  },
-  input: {
-    borderWidth: 1,
-    borderColor: "#e2e8f0",
-    borderRadius: 12,
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    fontSize: 16,
-    color: "#0f172a",
-  },
-  button: {
-    backgroundColor: "#1e40af",
-    borderRadius: 12,
-    paddingVertical: 14,
-    alignItems: "center",
-  },
-  buttonDisabled: {
-    opacity: 0.6,
-  },
-  buttonText: {
-    color: "#fff",
-    fontSize: 16,
-    fontWeight: "600",
-  },
-  linksRow: {
-    flexDirection: "row",
-    justifyContent: "center",
-  },
-  link: {
-    color: "#1e40af",
-    fontSize: 14,
-    fontWeight: "500",
-  },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+      justifyContent: "center",
+      paddingHorizontal: theme.spacing.xl,
+    },
+    card: {
+      gap: theme.spacing.lg,
+    },
+    logoContainer: {
+      alignItems: "center",
+      marginBottom: theme.spacing.xs,
+    },
+    title: {
+      textAlign: "center",
+      color: theme.colors.primaryText,
+    },
+    subtitle: {
+      textAlign: "center",
+    },
+    linksRow: {
+      flexDirection: "row",
+      justifyContent: "center",
+    },
+    link: {
+      color: theme.colors.primary,
+      fontWeight: "600",
+    },
+  });
+}

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,22 +1,23 @@
 import { Link, router } from "expo-router";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   Alert,
   KeyboardAvoidingView,
   Platform,
-  Pressable,
   StyleSheet,
-  Text,
-  TextInput,
   View,
 } from "react-native";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
+import { Body, Button, Card, Input, Subtitle, Title } from "../../components/ui";
+import { useTheme, type Theme } from "../../theme";
 
 export default function LoginScreen() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
 
   const handleLogin = async () => {
     if (!email || !password) {
@@ -49,106 +50,82 @@ export default function LoginScreen() {
       behavior={Platform.select({ ios: "padding", android: undefined })}
       style={styles.container}
     >
-      <View style={styles.card}>
+      <Card style={styles.card}>
         <View style={styles.logoContainer}>
           <BrandLogo size={80} />
         </View>
-        <Text style={styles.title}>Welcome back</Text>
-        <TextInput
+        <Title style={styles.title}>Welcome back</Title>
+        <Subtitle style={styles.subtitle}>
+          Sign in to manage estimates, customers, and your team from anywhere.
+        </Subtitle>
+        <Input
           autoCapitalize="none"
           autoComplete="email"
           autoCorrect={false}
           keyboardType="email-address"
-          placeholder="Email"
-          placeholderTextColor="#888"
-          style={styles.input}
+          placeholder="you@example.com"
+          label="Email"
           value={email}
           onChangeText={setEmail}
         />
-        <TextInput
+        <Input
           autoCapitalize="none"
           autoComplete="password"
-          placeholder="Password"
-          placeholderTextColor="#888"
+          placeholder="••••••••"
           secureTextEntry
-          style={styles.input}
+          label="Password"
           value={password}
           onChangeText={setPassword}
         />
-        <Pressable style={[styles.button, loading && styles.buttonDisabled]} onPress={handleLogin} disabled={loading}>
-          <Text style={styles.buttonText}>{loading ? "Signing in..." : "Sign in"}</Text>
-        </Pressable>
+        <Button
+          label="Sign in"
+          onPress={handleLogin}
+          loading={loading}
+          accessibilityLabel="Sign in to QuickQuote"
+        />
         <View style={styles.linksRow}>
-          <Link href="/(auth)/forgot-password" style={styles.link}>
-            Forgot password?
+          <Link href="/(auth)/forgot-password">
+            <Body style={styles.link}>Forgot password?</Body>
           </Link>
-          <Link href="/(auth)/signup" style={styles.link}>
-            Create account
+          <Link href="/(auth)/signup">
+            <Body style={styles.link}>Create account</Body>
           </Link>
         </View>
-      </View>
+      </Card>
     </KeyboardAvoidingView>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#0f172a",
-    justifyContent: "center",
-    paddingHorizontal: 24,
-  },
-  card: {
-    backgroundColor: "#fff",
-    borderRadius: 16,
-    padding: 24,
-    gap: 16,
-    shadowColor: "#000",
-    shadowOpacity: 0.15,
-    shadowOffset: { width: 0, height: 8 },
-    shadowRadius: 12,
-    elevation: 6,
-  },
-  logoContainer: {
-    alignItems: "center",
-    marginBottom: 4,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: "700",
-    color: "#0f172a",
-    textAlign: "center",
-  },
-  input: {
-    borderWidth: 1,
-    borderColor: "#e2e8f0",
-    borderRadius: 12,
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    fontSize: 16,
-    color: "#0f172a",
-  },
-  button: {
-    backgroundColor: "#1e40af",
-    borderRadius: 12,
-    paddingVertical: 14,
-    alignItems: "center",
-  },
-  buttonDisabled: {
-    opacity: 0.6,
-  },
-  buttonText: {
-    color: "#fff",
-    fontSize: 16,
-    fontWeight: "600",
-  },
-  linksRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-  },
-  link: {
-    color: "#1e40af",
-    fontSize: 14,
-    fontWeight: "500",
-  },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+      justifyContent: "center",
+      paddingHorizontal: theme.spacing.xl,
+    },
+    card: {
+      gap: theme.spacing.lg,
+    },
+    logoContainer: {
+      alignItems: "center",
+      marginBottom: theme.spacing.xs,
+    },
+    title: {
+      textAlign: "center",
+      color: theme.colors.primaryText,
+    },
+    subtitle: {
+      textAlign: "center",
+    },
+    linksRow: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+    },
+    link: {
+      color: theme.colors.primary,
+      fontWeight: "600",
+    },
+  });
+}

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -1,20 +1,12 @@
 import { Link, router } from "expo-router";
-import { useEffect, useState } from "react";
-import {
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
+import { useEffect, useMemo, useState } from "react";
+import { Alert, KeyboardAvoidingView, Platform, ScrollView, StyleSheet, View } from "react-native";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
 import LogoPicker from "../../components/LogoPicker";
 import { useSettings } from "../../context/SettingsContext";
+import { Body, Button, Card, Input, Subtitle, Title } from "../../components/ui";
+import { useTheme, type Theme } from "../../theme";
 
 export default function SignupScreen() {
   const [email, setEmail] = useState("");
@@ -28,6 +20,8 @@ export default function SignupScreen() {
   const [logoUri, setLogoUri] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const { settings, setCompanyProfile } = useSettings();
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
 
   useEffect(() => {
     setCompanyName(settings.companyProfile.name ?? "");
@@ -88,188 +82,140 @@ export default function SignupScreen() {
       style={styles.container}
     >
       <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
-        <View style={styles.card}>
+        <Card style={styles.card}>
           <View style={styles.logoContainer}>
             <BrandLogo size={80} />
           </View>
-          <Text style={styles.title}>Create your account</Text>
+          <Title style={styles.title}>Create your account</Title>
           <View style={styles.section}>
-            <Text style={styles.sectionTitle}>Account details</Text>
-            <Text style={styles.sectionSubtitle}>
+            <Subtitle style={styles.sectionTitle}>Account details</Subtitle>
+            <Body style={styles.sectionSubtitle}>
               Sign in with your work email so we can keep your estimates in sync.
-            </Text>
-            <TextInput
+            </Body>
+            <Input
               autoCapitalize="none"
               autoComplete="email"
               autoCorrect={false}
               keyboardType="email-address"
-              placeholder="Email"
-              placeholderTextColor="#888"
-              style={styles.input}
+              placeholder="you@example.com"
+              label="Email"
               value={email}
               onChangeText={setEmail}
             />
-            <TextInput
+            <Input
               autoCapitalize="none"
               autoComplete="password"
-              placeholder="Password"
-              placeholderTextColor="#888"
+              placeholder="Create a password"
               secureTextEntry
-              style={styles.input}
+              label="Password"
               value={password}
               onChangeText={setPassword}
             />
-            <TextInput
+            <Input
               autoCapitalize="none"
               autoComplete="password"
-              placeholder="Confirm password"
-              placeholderTextColor="#888"
+              placeholder="Confirm your password"
               secureTextEntry
-              style={styles.input}
+              label="Confirm password"
               value={confirmPassword}
               onChangeText={setConfirmPassword}
             />
           </View>
 
           <View style={styles.section}>
-            <Text style={styles.sectionTitle}>Company profile</Text>
-            <Text style={styles.sectionSubtitle}>
-              We’ll preload every estimate with this information. You can tweak it anytime in Settings.
-            </Text>
+            <Subtitle style={styles.sectionTitle}>Company profile</Subtitle>
+            <Body style={styles.sectionSubtitle}>
+              We’ll preload every estimate with this information. You can tweak it anytime in
+              Settings.
+            </Body>
             <LogoPicker value={logoUri} onChange={setLogoUri} />
-            <TextInput
-              placeholder="Company name"
-              placeholderTextColor="#888"
-              style={styles.input}
+            <Input
+              placeholder="Acme Landscaping"
+              label="Company name"
               value={companyName}
               onChangeText={setCompanyName}
             />
-            <TextInput
-              placeholder="Company email"
-              placeholderTextColor="#888"
+            <Input
+              placeholder="hello@acme.com"
               keyboardType="email-address"
               autoCapitalize="none"
-              style={styles.input}
+              label="Company email"
               value={companyEmail}
               onChangeText={setCompanyEmail}
             />
-            <TextInput
-              placeholder="Phone"
-              placeholderTextColor="#888"
+            <Input
+              placeholder="(555) 555-0199"
               keyboardType="phone-pad"
-              style={styles.input}
+              label="Phone"
               value={companyPhone}
               onChangeText={setCompanyPhone}
             />
-            <TextInput
-              placeholder="Website"
-              placeholderTextColor="#888"
+            <Input
+              placeholder="https://acme.com"
               autoCapitalize="none"
-              style={styles.input}
+              label="Website"
               value={companyWebsite}
               onChangeText={setCompanyWebsite}
             />
-            <TextInput
-              placeholder="Business address"
-              placeholderTextColor="#888"
-              style={[styles.input, styles.textArea]}
+            <Input
+              placeholder="123 Main St, Springfield"
+              label="Business address"
               value={companyAddress}
               onChangeText={setCompanyAddress}
               multiline
             />
           </View>
 
-          <Pressable style={[styles.button, loading && styles.buttonDisabled]} onPress={handleSignup} disabled={loading}>
-            <Text style={styles.buttonText}>{loading ? "Creating account..." : "Sign up"}</Text>
-          </Pressable>
+          <Button label="Sign up" onPress={handleSignup} loading={loading} />
           <View style={styles.linksRow}>
-            <Link href="/(auth)/login" style={styles.link}>
-              Already have an account?
+            <Link href="/(auth)/login">
+              <Body style={styles.link}>Already have an account?</Body>
             </Link>
           </View>
-        </View>
+        </Card>
       </ScrollView>
     </KeyboardAvoidingView>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#0f172a",
-    justifyContent: "center",
-    paddingHorizontal: 24,
-  },
-  card: {
-    backgroundColor: "#fff",
-    borderRadius: 16,
-    padding: 24,
-    gap: 20,
-    shadowColor: "#000",
-    shadowOpacity: 0.15,
-    shadowOffset: { width: 0, height: 8 },
-    shadowRadius: 12,
-    elevation: 6,
-  },
-  scrollContent: {
-    paddingVertical: 24,
-  },
-  logoContainer: {
-    alignItems: "center",
-    marginBottom: 4,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: "700",
-    color: "#0f172a",
-    textAlign: "center",
-  },
-  section: {
-    gap: 12,
-  },
-  sectionTitle: {
-    fontSize: 18,
-    fontWeight: "700",
-    color: "#0f172a",
-  },
-  sectionSubtitle: {
-    fontSize: 14,
-    color: "#475569",
-  },
-  input: {
-    borderWidth: 1,
-    borderColor: "#e2e8f0",
-    borderRadius: 12,
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    fontSize: 16,
-    color: "#0f172a",
-  },
-  textArea: {
-    minHeight: 90,
-    textAlignVertical: "top",
-  },
-  button: {
-    backgroundColor: "#1e40af",
-    borderRadius: 12,
-    paddingVertical: 14,
-    alignItems: "center",
-  },
-  buttonDisabled: {
-    opacity: 0.6,
-  },
-  buttonText: {
-    color: "#fff",
-    fontSize: 16,
-    fontWeight: "600",
-  },
-  linksRow: {
-    flexDirection: "row",
-    justifyContent: "center",
-  },
-  link: {
-    color: "#1e40af",
-    fontSize: 14,
-    fontWeight: "500",
-  },
-});
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+      justifyContent: "center",
+      paddingHorizontal: theme.spacing.xl,
+    },
+    card: {
+      gap: theme.spacing.xl,
+    },
+    scrollContent: {
+      paddingVertical: theme.spacing.xl,
+    },
+    logoContainer: {
+      alignItems: "center",
+      marginBottom: theme.spacing.xs,
+    },
+    title: {
+      textAlign: "center",
+      color: theme.colors.primaryText,
+    },
+    section: {
+      gap: theme.spacing.md,
+    },
+    sectionTitle: {
+      color: theme.colors.primaryText,
+    },
+    sectionSubtitle: {
+      color: theme.colors.textMuted,
+    },
+    linksRow: {
+      flexDirection: "row",
+      justifyContent: "center",
+    },
+    link: {
+      color: theme.colors.primary,
+      fontWeight: "600",
+    },
+  });
+}

--- a/components/ui/Typography.tsx
+++ b/components/ui/Typography.tsx
@@ -1,0 +1,69 @@
+import { PropsWithChildren, useMemo } from "react";
+import { StyleProp, StyleSheet, Text, TextProps, TextStyle } from "react-native";
+import { useTheme, type Theme } from "../../theme";
+
+type TypographyProps = TextProps & {
+  style?: StyleProp<TextStyle>;
+};
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    title: {
+      fontSize: 24,
+      fontWeight: "700",
+      color: theme.colors.text,
+      letterSpacing: 0.3,
+    },
+    subtitle: {
+      fontSize: 16,
+      fontWeight: "500",
+      color: theme.colors.textMuted,
+      letterSpacing: 0.2,
+    },
+    body: {
+      fontSize: 14,
+      color: theme.colors.text,
+      letterSpacing: 0.1,
+      lineHeight: 20,
+    },
+  });
+}
+
+export function Title({ style, children, ...props }: PropsWithChildren<TypographyProps>) {
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <Text accessibilityRole="header" {...props} style={[styles.title, style]}>
+      {children}
+    </Text>
+  );
+}
+
+export function Subtitle({ style, children, ...props }: PropsWithChildren<TypographyProps>) {
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <Text {...props} style={[styles.subtitle, style]}>
+      {children}
+    </Text>
+  );
+}
+
+export function Body({ style, children, ...props }: PropsWithChildren<TypographyProps>) {
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <Text {...props} style={[styles.body, style]}>
+      {children}
+    </Text>
+  );
+}
+
+export type Typography = {
+  Title: typeof Title;
+  Subtitle: typeof Subtitle;
+  Body: typeof Body;
+};

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -10,3 +10,4 @@ export { ListItem } from "./ListItem";
 export type { ListItemProps } from "./ListItem";
 export { FAB } from "./FAB";
 export type { FABProps } from "./FAB";
+export { Title, Subtitle, Body } from "./Typography";


### PR DESCRIPTION
## Summary
- replace native inputs and pressables in the auth flow with the shared Button, Card, Input, and typography primitives
- add reusable Title, Subtitle, and Body text components to centralize typography styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd6a7d72d883238c113671ad8d1d73