### PR TITLE
Refactor settings tab with design system cards

### DIFF
--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -11,7 +11,7 @@ import {
 } from "react-native";
 import { useTheme } from "../../theme";
 
-export type ButtonVariant = "primary" | "secondary" | "ghost";
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
 
 type ButtonAlignment = "inline" | "full";
 
@@ -66,7 +66,11 @@ export function Button({
       <View style={[styles.content, contentStyle]}>
         {loading ? (
           <ActivityIndicator
-            color={variant === "primary" ? theme.colors.surface : theme.colors.primary}
+            color={
+              variant === "primary" || variant === "danger"
+                ? theme.colors.surface
+                : theme.colors.primary
+            }
           />
         ) : (
           <>
@@ -123,6 +127,12 @@ function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
     },
     ghostLabel: {
       color: theme.colors.primary,
+    },
+    danger: {
+      backgroundColor: theme.colors.danger,
+    },
+    dangerLabel: {
+      color: theme.colors.surface,
     },
     fullWidth: {
       alignSelf: "stretch",


### PR DESCRIPTION
## Summary
- redesign the settings tab around design system cards, list items, and inputs while keeping existing preference logic intact
- add inline controls for theme, toggles, markup values, and estimate fine print plus refreshed data, about, and danger sections
- extend the shared Button component with a danger variant for destructive actions

## Testing
- npm run lint *(fails: ESLint 9 requires eslint.config.js migration in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8e441a3083239a843dd14f9dadb5