### PR TITLE
Refactor estimate line items to new UI

### DIFF
--- a/app/(tabs)/estimates/[id].tsx
+++ b/app/(tabs)/estimates/[id].tsx
@@ -4,7 +4,6 @@ import { router, useLocalSearchParams } from "expo-router";
 import {
   ActivityIndicator,
   Alert,
-  Button as RNButton,
   FlatList,
   Image,
   Linking,
@@ -813,53 +812,45 @@ export default function EditEstimateScreen() {
 
   const renderItem = useCallback(
     ({ item }: { item: EstimateItemRecord }) => (
-      <View style={styles.itemCard}>
-        <View style={styles.itemInfo}>
-          <Text style={styles.itemTitle}>{item.description}</Text>
-          <Text style={styles.itemMeta}>
-            Qty: {item.quantity} @ {formatCurrency(item.unit_price)}
-          </Text>
-          <Text style={styles.itemMeta}>Line Total: {formatCurrency(item.total)}</Text>
-        </View>
-        <View style={styles.inlineButtons}>
-          <View style={styles.buttonFlex}>
-            <RNButton
-              title="Edit"
-              color={colors.primary}
-              onPress={() =>
-                openItemEditorScreen({
-                  title: "Edit Item",
-                  submitLabel: "Update Item",
-                  initialValue: {
-                    description: item.description,
-                    quantity: item.quantity,
-                    unit_price: item.unit_price,
-                  },
-                  initialTemplateId: item.catalog_item_id,
-                  templates: () => savedItemTemplates,
-                  onSubmit: makeItemSubmitHandler(item),
-                })
-              }
-            />
-          </View>
-          <View style={styles.buttonFlex}>
-            <RNButton
-              title="Remove"
-              color={colors.danger}
-              onPress={() => handleDeleteItem(item)}
-            />
-          </View>
+      <View style={styles.lineItemRow}>
+        <ListItem
+          title={item.description}
+          subtitle={`Qty: ${item.quantity} @ ${formatCurrency(item.unit_price)}`}
+          rightContent={<Text style={styles.lineItemTotal}>{formatCurrency(item.total)}</Text>}
+          style={styles.lineItem}
+        />
+        <View style={styles.lineItemActions}>
+          <Button
+            label="Edit"
+            variant="secondary"
+            alignment="inline"
+            onPress={() =>
+              openItemEditorScreen({
+                title: "Edit Item",
+                submitLabel: "Update Item",
+                initialValue: {
+                  description: item.description,
+                  quantity: item.quantity,
+                  unit_price: item.unit_price,
+                },
+                initialTemplateId: item.catalog_item_id,
+                templates: () => savedItemTemplates,
+                onSubmit: makeItemSubmitHandler(item),
+              })
+            }
+            style={styles.lineItemActionButton}
+          />
+          <Button
+            label="Remove"
+            variant="danger"
+            alignment="inline"
+            onPress={() => handleDeleteItem(item)}
+            style={styles.lineItemActionButton}
+          />
         </View>
       </View>
     ),
-    [
-      colors.danger,
-      colors.primary,
-      handleDeleteItem,
-      makeItemSubmitHandler,
-      openItemEditorScreen,
-      savedItemTemplates,
-    ],
+    [handleDeleteItem, makeItemSubmitHandler, openItemEditorScreen, savedItemTemplates],
   );
 
   const handlePhotoDraftChange = useCallback((photoId: string, value: string) => {
@@ -1836,26 +1827,28 @@ export default function EditEstimateScreen() {
           />
         </Card>
 
-        <View style={styles.card}>
-          <Text style={styles.sectionTitle}>Estimate items</Text>
-          <Text style={styles.sectionSubtitle}>
-            Track the work you&apos;re quoting. Saved items help you move fast.
-          </Text>
+        <Card style={styles.lineItemsCard}>
+          <View style={styles.lineItemsHeader}>
+            <Text style={styles.sectionTitle}>Estimate items</Text>
+            <Text style={styles.sectionSubtitle}>
+              Track the work you&apos;re quoting. Saved items help you move fast.
+            </Text>
+          </View>
           <FlatList
             data={items}
             keyExtractor={(item) => item.id}
             renderItem={renderItem}
             scrollEnabled={false}
-            ItemSeparatorComponent={() => <View style={styles.itemSeparator} />}
+            ItemSeparatorComponent={() => <View style={styles.lineItemSeparator} />}
+            contentContainerStyle={styles.lineItemsList}
             ListEmptyComponent={
               <View style={styles.emptyCard}>
                 <Text style={styles.emptyText}>No items added yet.</Text>
               </View>
             }
           />
-          <RNButton
-            title="Add line item"
-            color={colors.primary}
+          <Button
+            label="Add line item"
             onPress={() =>
               openItemEditorScreen({
                 title: "Add line item",
@@ -1865,8 +1858,9 @@ export default function EditEstimateScreen() {
                 onSubmit: makeItemSubmitHandler(null),
               })
             }
+            style={styles.lineItemAddButton}
           />
-        </View>
+        </Card>
 
         <View style={styles.card}>
           <Text style={styles.sectionTitle}>Labor &amp; tax</Text>
@@ -2362,27 +2356,41 @@ function createStyles(theme: Theme) {
     emptyText: {
       color: colors.textMuted,
     },
-    itemSeparator: {
-      height: 12,
+    lineItemsCard: {
+      gap: spacing.lg,
     },
-    itemCard: {
+    lineItemsHeader: {
+      gap: spacing.xs,
+    },
+    lineItemsList: {
+      paddingVertical: spacing.xs,
+    },
+    lineItemRow: {
+      gap: spacing.sm,
+    },
+    lineItem: {
       backgroundColor: colors.surfaceMuted,
-      borderRadius: 16,
-      padding: 16,
-      gap: 8,
       borderWidth: StyleSheet.hairlineWidth,
       borderColor: colors.border,
-      ...cardShadow(6, theme.mode),
+      borderRadius: radii.lg,
     },
-    itemInfo: {
-      gap: 4,
-    },
-    itemTitle: {
+    lineItemTotal: {
+      fontSize: 16,
       fontWeight: "600",
       color: colors.primaryText,
     },
-    itemMeta: {
-      color: colors.textMuted,
+    lineItemActions: {
+      flexDirection: "row",
+      gap: spacing.md,
+    },
+    lineItemActionButton: {
+      flex: 1,
+    },
+    lineItemSeparator: {
+      height: spacing.md,
+    },
+    lineItemAddButton: {
+      marginTop: spacing.sm,
     },
     inputRow: {
       flexDirection: "row",

--- a/components/ui/ListItem.tsx
+++ b/components/ui/ListItem.tsx
@@ -7,6 +7,7 @@ export interface ListItemProps {
   subtitle?: string;
   amount?: string;
   badge?: ReactNode;
+  rightContent?: ReactNode;
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
   titleStyle?: StyleProp<TextStyle>;
@@ -19,6 +20,7 @@ export function ListItem({
   subtitle,
   amount,
   badge,
+  rightContent,
   onPress,
   style,
   titleStyle,
@@ -27,6 +29,14 @@ export function ListItem({
 }: ListItemProps) {
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  let resolvedRightContent: ReactNode | null = rightContent ?? null;
+  if (!resolvedRightContent) {
+    if (badge) {
+      resolvedRightContent = badge;
+    } else if (amount) {
+      resolvedRightContent = <Text style={[styles.amount, amountStyle]}>{amount}</Text>;
+    }
+  }
   if (onPress) {
     return (
       <Pressable
@@ -38,13 +48,7 @@ export function ListItem({
           <Text style={[styles.title, titleStyle]}>{title}</Text>
           {subtitle ? <Text style={[styles.subtitle, subtitleStyle]}>{subtitle}</Text> : null}
         </View>
-        <View style={styles.rightColumn}>
-          {badge ? (
-            badge
-          ) : amount ? (
-            <Text style={[styles.amount, amountStyle]}>{amount}</Text>
-          ) : null}
-        </View>
+        <View style={styles.rightColumn}>{resolvedRightContent}</View>
       </Pressable>
     );
   }
@@ -55,9 +59,7 @@ export function ListItem({
         <Text style={[styles.title, titleStyle]}>{title}</Text>
         {subtitle ? <Text style={[styles.subtitle, subtitleStyle]}>{subtitle}</Text> : null}
       </View>
-      <View style={styles.rightColumn}>
-        {badge ? badge : amount ? <Text style={[styles.amount, amountStyle]}>{amount}</Text> : null}
-      </View>
+      <View style={styles.rightColumn}>{resolvedRightContent}</View>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the estimate items section in the shared Card component and present rows with ListItem plus inline action buttons
- replace legacy React Native buttons with design system Buttons, including a primary "Add line item" call-to-action
- extend the ListItem component to support custom right-side content so totals can be shown alongside each item

## Testing
- npm run lint (emits existing Prettier warnings in unrelated files)
- npx eslint 'app/(tabs)/estimates/[id].tsx' components/ui/ListItem.tsx


------
https://chatgpt.com/codex/tasks/task_e_68de77a742d88323af1ad16019d633ee