### PR TITLE
Implement theme context with manual dark mode toggle

### DIFF
--- a/__tests__/home.test.tsx
+++ b/__tests__/home.test.tsx
@@ -10,15 +10,14 @@ jest.mock("expo-router", () => {
   };
 });
 
-jest.mock("../theme", () => {
-  const actual = jest.requireActual("../theme");
+jest.mock("../theme/ThemeProvider", () => {
+  const actualTheme = jest.requireActual("../theme");
   return {
-    ...actual,
-    useTheme: () => ({
-      mode: "light" as const,
-      theme: actual.light,
-      setMode: jest.fn(),
-      toggleMode: jest.fn(),
+    ...jest.requireActual("../theme/ThemeProvider"),
+    useThemeContext: () => ({
+      theme: actualTheme.light,
+      isDark: false,
+      toggleTheme: jest.fn(),
     }),
   };
 });

--- a/app/(auth)/forgot-password.tsx
+++ b/app/(auth)/forgot-password.tsx
@@ -4,14 +4,15 @@ import { Alert, KeyboardAvoidingView, Platform, StyleSheet, View } from "react-n
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
 import { Body, Button, Card, Input, Subtitle, Title } from "../../components/ui";
-import { useTheme, type Theme } from "../../theme";
+import { Theme } from "../../theme";
+import { useThemeContext } from "../../theme/ThemeProvider";
 
 const RESET_REDIRECT = process.env.EXPO_PUBLIC_SUPABASE_RESET_REDIRECT;
 
 export default function ForgotPasswordScreen() {
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   const handleReset = async () => {

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -4,13 +4,14 @@ import { Alert, KeyboardAvoidingView, Platform, StyleSheet, View } from "react-n
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
 import { Body, Button, Card, Input, Subtitle, Title } from "../../components/ui";
-import { useTheme, type Theme } from "../../theme";
+import { Theme } from "../../theme";
+import { useThemeContext } from "../../theme/ThemeProvider";
 
 export default function LoginScreen() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   const handleLogin = async () => {

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -6,7 +6,8 @@ import { BrandLogo } from "../../components/BrandLogo";
 import LogoPicker from "../../components/LogoPicker";
 import { useSettings } from "../../context/SettingsContext";
 import { Body, Button, Card, Input, Subtitle, Title } from "../../components/ui";
-import { useTheme, type Theme } from "../../theme";
+import { Theme } from "../../theme";
+import { useThemeContext } from "../../theme/ThemeProvider";
 
 export default function SignupScreen() {
   const [email, setEmail] = useState("");
@@ -20,7 +21,7 @@ export default function SignupScreen() {
   const [logoUri, setLogoUri] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const { settings, setCompanyProfile } = useSettings();
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   useEffect(() => {

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -3,17 +3,19 @@ import { Ionicons } from "@expo/vector-icons";
 import { ActivityIndicator, StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAuth } from "../../context/AuthContext";
+import { useThemeContext } from "../../theme/ThemeProvider";
 
 export default function TabsLayout() {
   const { session, isLoading } = useAuth();
   const insets = useSafeAreaInsets();
+  const { theme } = useThemeContext();
   const palette = {
-    background: "#f8fafc",
-    card: "#ffffff",
-    accent: "#1e40af",
-    primaryText: "#0f172a",
-    muted: "#64748b",
-    border: "#e2e8f0",
+    background: theme.colors.surface,
+    card: theme.colors.surfaceMuted,
+    accent: theme.colors.primary,
+    primaryText: theme.colors.primaryText,
+    muted: theme.colors.textMuted,
+    border: theme.colors.border,
   };
 
   if (isLoading) {
@@ -43,7 +45,7 @@ export default function TabsLayout() {
           backgroundColor: palette.background,
           borderTopWidth: 1,
           borderTopColor: palette.border,
-          shadowColor: palette.primaryText,
+          shadowColor: theme.colors.overlay,
           shadowOpacity: 0.06,
           shadowOffset: { width: 0, height: -4 },
           shadowRadius: 12,

--- a/app/(tabs)/customers.tsx
+++ b/app/(tabs)/customers.tsx
@@ -12,7 +12,8 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import CustomerForm from "../../components/CustomerForm";
 import { Badge, Button, Card, FAB, Input, ListItem } from "../../components/ui";
-import { useTheme, type Theme } from "../../theme";
+import { Theme } from "../../theme";
+import { useThemeContext } from "../../theme/ThemeProvider";
 import { openDB, queueChange } from "../../lib/sqlite";
 import { runSync } from "../../lib/sync";
 
@@ -36,7 +37,7 @@ type EditCustomerFormProps = {
 };
 
 function EditCustomerForm({ customer, onCancel, onSaved }: EditCustomerFormProps) {
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createEditStyles(theme), [theme]);
   const [name, setName] = useState(customer.name);
   const [phone, setPhone] = useState(customer.phone ?? "");
@@ -161,7 +162,7 @@ function EditCustomerForm({ customer, onCancel, onSaved }: EditCustomerFormProps
 }
 
 export default function Customers() {
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const [customers, setCustomers] = useState<CustomerRecord[]>([]);
   const [loading, setLoading] = useState(true);

--- a/app/(tabs)/estimates/[id].tsx
+++ b/app/(tabs)/estimates/[id].tsx
@@ -57,7 +57,8 @@ import {
   Title,
   type BadgeTone,
 } from "../../../components/ui";
-import { useTheme, type Theme } from "../../../theme";
+import { Theme } from "../../../theme";
+import { useThemeContext } from "../../../theme/ThemeProvider";
 import type { EstimateListItem } from "./index";
 import { v4 as uuidv4 } from "uuid";
 
@@ -178,7 +179,7 @@ export default function EditEstimateScreen() {
   const estimateId = params.id ?? "";
   const { user, session } = useAuth();
   const { settings } = useSettings();
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const previewStyles = useMemo(() => createPreviewStyles(theme), [theme]);
   const colors = theme.colors;

--- a/app/(tabs)/estimates/index.tsx
+++ b/app/(tabs)/estimates/index.tsx
@@ -12,7 +12,8 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Badge, Button, Card, FAB, Input, ListItem } from "../../../components/ui";
 import { openDB } from "../../../lib/sqlite";
-import { useTheme, type Theme } from "../../../theme";
+import { Theme } from "../../../theme";
+import { useThemeContext } from "../../../theme/ThemeProvider";
 
 type EstimateListItem = {
   id: string;
@@ -88,7 +89,7 @@ function formatEstimateNumber(estimate: EstimateListItem): string {
 }
 
 export default function EstimatesScreen() {
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const [estimates, setEstimates] = useState<EstimateListItem[]>([]);
   const [loading, setLoading] = useState(true);

--- a/app/(tabs)/estimates/item-editor.tsx
+++ b/app/(tabs)/estimates/item-editor.tsx
@@ -4,7 +4,8 @@ import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from "react-nat
 import EstimateItemForm from "../../../components/EstimateItemForm";
 import { useItemEditor } from "../../../context/ItemEditorContext";
 import { Card } from "../../../components/ui";
-import { useTheme, type Theme } from "../../../theme";
+import { Theme } from "../../../theme";
+import { useThemeContext } from "../../../theme/ThemeProvider";
 
 function createStyles(theme: Theme) {
   const { colors } = theme;
@@ -40,7 +41,7 @@ export default function EstimateItemEditorScreen() {
   const { config, closeEditor } = useItemEditor();
   const hasNavigatedAway = useRef(false);
   const hasLoadedConfigRef = useRef(false);
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   useEffect(() => {

--- a/app/(tabs)/estimates/new.tsx
+++ b/app/(tabs)/estimates/new.tsx
@@ -12,7 +12,8 @@ import { sanitizeEstimateForQueue } from "../../../lib/estimates";
 import { calculateEstimateTotals } from "../../../lib/estimateMath";
 import { openDB, queueChange } from "../../../lib/sqlite";
 import { runSync } from "../../../lib/sync";
-import { useTheme, type Theme } from "../../../theme";
+import { Theme } from "../../../theme";
+import { useThemeContext } from "../../../theme/ThemeProvider";
 import type { EstimateItemFormSubmit } from "../../../components/EstimateItemForm";
 
 const CURRENCY_FORMATTER = new Intl.NumberFormat("en-US", {
@@ -162,7 +163,7 @@ function createStyles(theme: Theme) {
 export default function NewEstimateScreen() {
   const { user, session } = useAuth();
   const { settings } = useSettings();
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const router = useRouter();
   const insets = useSafeAreaInsets();

--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -18,7 +18,8 @@ import {
   ListItem,
   Title,
 } from "../../components/ui";
-import { useTheme, type Theme } from "../../theme";
+import { Theme } from "../../theme";
+import { useThemeContext } from "../../theme/ThemeProvider";
 
 type DashboardMetrics = {
   jobsSold: number;
@@ -233,7 +234,7 @@ function formatStatus(value: string) {
 
 export default function Home() {
   const insets = useSafeAreaInsets();
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const [metrics, setMetrics] = useState<DashboardMetrics | null>(null);
   const [loading, setLoading] = useState(true);

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -16,7 +16,8 @@ import { Badge, Button, Card, Input, ListItem } from "../../components/ui";
 import LogoPicker from "../../components/LogoPicker";
 import { useAuth } from "../../context/AuthContext";
 import { type ThemePreference, useSettings } from "../../context/SettingsContext";
-import { useTheme } from "../../theme";
+import { Theme } from "../../theme";
+import { useThemeContext } from "../../theme/ThemeProvider";
 
 const THEME_OPTIONS = [
   { label: "Light", value: "light" },
@@ -27,7 +28,7 @@ const THEME_OPTIONS = [
 const HAPTIC_LABELS = ["Subtle", "Balanced", "Bold"];
 
 export default function Settings() {
-  const { theme } = useTheme();
+  const { theme, isDark, toggleTheme } = useThemeContext();
   const { user, signOut, signOutLoading, needsBootstrapRetry } = useAuth();
   const {
     settings,
@@ -313,6 +314,13 @@ export default function Settings() {
             style={styles.listItem}
           />
         </View>
+        <View style={styles.buttonRow}>
+          <Button
+            label={isDark ? "Switch to Light Mode" : "Switch to Dark Mode"}
+            alignment="inline"
+            onPress={toggleTheme}
+          />
+        </View>
         {isEditingTaxRate ? (
           <Input
             label="Sales tax percentage"
@@ -453,7 +461,7 @@ export default function Settings() {
   );
 }
 
-function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
+function createStyles(theme: Theme) {
   return StyleSheet.create({
     container: {
       flex: 1,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,5 @@
 import { Stack } from "expo-router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   AppState,
@@ -13,10 +13,61 @@ import { AuthProvider, useAuth } from "../context/AuthContext";
 import { SettingsProvider } from "../context/SettingsContext";
 import { initLocalDB } from "../lib/sqlite";
 import { runSync } from "../lib/sync";
-import { ThemeProvider } from "../theme";
+import { ThemeProvider, useThemeContext } from "../theme/ThemeProvider";
+import { Theme } from "../theme";
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    loadingContainer: {
+      alignItems: "center",
+      flex: 1,
+      justifyContent: "center",
+    },
+    rootContainer: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    retryBanner: {
+      backgroundColor: theme.colors.warningSoft,
+      borderBottomColor: theme.colors.warning,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      paddingHorizontal: theme.spacing.xl,
+      paddingVertical: theme.spacing.md,
+    },
+    retryBannerTitle: {
+      color: theme.colors.warning,
+      fontSize: 16,
+      fontWeight: "600",
+      marginBottom: 4,
+    },
+    retryBannerMessage: {
+      color: theme.colors.text,
+      fontSize: 14,
+      lineHeight: 20,
+      marginBottom: 12,
+    },
+    retryButton: {
+      alignSelf: "flex-start",
+      backgroundColor: theme.colors.warning,
+      borderRadius: theme.radii.sm,
+      paddingHorizontal: theme.spacing.lg,
+      paddingVertical: theme.spacing.sm,
+    },
+    retryButtonDisabled: {
+      opacity: 0.6,
+    },
+    retryButtonText: {
+      color: theme.colors.surface,
+      fontSize: 14,
+      fontWeight: "600",
+    },
+  });
+}
 
 function RootNavigator() {
   const { isLoading, needsBootstrapRetry, retryBootstrap } = useAuth();
+  const { theme } = useThemeContext();
+  const styles = useMemo(() => createStyles(theme), [theme]);
   const [retryingBootstrap, setRetryingBootstrap] = useState(false);
 
   useEffect(() => {
@@ -118,48 +169,3 @@ export default function RootLayout() {
     </ThemeProvider>
   );
 }
-
-const styles = StyleSheet.create({
-  loadingContainer: {
-    alignItems: "center",
-    flex: 1,
-    justifyContent: "center",
-  },
-  rootContainer: {
-    flex: 1,
-  },
-  retryBanner: {
-    backgroundColor: "#FEF3C7",
-    borderBottomColor: "#FCD34D",
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-  },
-  retryBannerTitle: {
-    color: "#92400E",
-    fontSize: 16,
-    fontWeight: "600",
-    marginBottom: 4,
-  },
-  retryBannerMessage: {
-    color: "#B45309",
-    fontSize: 14,
-    lineHeight: 20,
-    marginBottom: 12,
-  },
-  retryButton: {
-    alignSelf: "flex-start",
-    backgroundColor: "#B45309",
-    borderRadius: 8,
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-  },
-  retryButtonDisabled: {
-    opacity: 0.6,
-  },
-  retryButtonText: {
-    color: "#FFFBEB",
-    fontSize: 14,
-    fontWeight: "600",
-  },
-});

--- a/components/CustomerPicker.tsx
+++ b/components/CustomerPicker.tsx
@@ -4,7 +4,8 @@ import { ActivityIndicator, Alert, StyleSheet, Text, View } from "react-native";
 import { Picker } from "@react-native-picker/picker";
 import { openDB } from "../lib/sqlite";
 import CustomerForm from "./CustomerForm";
-import { useTheme, type Theme } from "../theme";
+import { Theme } from "../theme";
+import { useThemeContext } from "../theme/ThemeProvider";
 import { Button, Card, Input } from "./ui";
 
 type Customer = {
@@ -26,7 +27,7 @@ export default function CustomerPicker({ selectedCustomer, onSelect }: Props) {
   const [loading, setLoading] = useState(true);
   const [addingNew, setAddingNew] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   const loadCustomers = useCallback(async () => {

--- a/components/EstimateItemForm.tsx
+++ b/components/EstimateItemForm.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Alert, StyleSheet, Switch, Text, View } from "react-native";
 import { Picker } from "@react-native-picker/picker";
-import { useTheme, type Theme } from "../theme";
+import { Theme } from "../theme";
+import { useThemeContext } from "../theme/ThemeProvider";
 import { Button, Input } from "./ui";
 
 export type EstimateItemFormValues = {
@@ -81,7 +82,7 @@ export default function EstimateItemForm({
   );
   const [saveToLibrary, setSaveToLibrary] = useState<boolean>(true);
   const [submitting, setSubmitting] = useState(false);
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   useEffect(() => {

--- a/components/LogoPicker.tsx
+++ b/components/LogoPicker.tsx
@@ -1,7 +1,9 @@
-import { useCallback } from "react";
-import { Alert, Image, Pressable, StyleSheet, Text, useColorScheme, View } from "react-native";
+import { useCallback, useMemo } from "react";
+import { Alert, Image, Pressable, StyleSheet, Text, View } from "react-native";
 import * as ImagePicker from "expo-image-picker";
 import BrandLogo from "./BrandLogo";
+import { Theme } from "../theme";
+import { useThemeContext } from "../theme/ThemeProvider";
 
 type LogoPickerProps = {
   label?: string;
@@ -9,9 +11,74 @@ type LogoPickerProps = {
   onChange: (uri: string | null) => void;
 };
 
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    container: {
+      gap: 8,
+    },
+    label: {
+      fontSize: 16,
+      fontWeight: "600",
+      color: theme.colors.text,
+    },
+    previewRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 16,
+    },
+    previewContainer: {
+      width: 88,
+      height: 88,
+      borderRadius: 18,
+      borderWidth: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      overflow: "hidden",
+      backgroundColor: theme.colors.surface,
+      borderColor: theme.colors.border,
+    },
+    previewImage: {
+      width: "100%",
+      height: "100%",
+    },
+    placeholderLogo: {
+      opacity: 0.7,
+    },
+    actions: {
+      flex: 1,
+      gap: 8,
+    },
+    button: {
+      paddingVertical: 10,
+      paddingHorizontal: 14,
+      borderRadius: 12,
+      borderWidth: 1,
+      alignItems: "center",
+    },
+    buttonText: {
+      textAlign: "center",
+      fontWeight: "600",
+    },
+    primaryButton: {
+      backgroundColor: theme.colors.primary,
+      borderColor: theme.colors.primary,
+    },
+    primaryButtonText: {
+      color: theme.colors.surface,
+    },
+    secondaryButton: {
+      backgroundColor: theme.colors.surface,
+      borderColor: theme.colors.border,
+    },
+    secondaryButtonText: {
+      color: theme.colors.primaryText,
+    },
+  });
+}
+
 export function LogoPicker({ label = "Company logo", value, onChange }: LogoPickerProps) {
-  const colorScheme = useColorScheme();
-  const isDark = colorScheme === "dark";
+  const { theme } = useThemeContext();
+  const styles = useMemo(() => createStyles(theme), [theme]);
 
   const handlePick = useCallback(async () => {
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
@@ -44,24 +111,11 @@ export function LogoPicker({ label = "Company logo", value, onChange }: LogoPick
     onChange(null);
   }, [onChange]);
 
-  const palette = {
-    text: isDark ? "#e2e8f0" : "#1f2937",
-    muted: isDark ? "#94a3b8" : "#475569",
-    surface: isDark ? "#1e293b" : "#f8fafc",
-    border: isDark ? "#334155" : "#cbd5f5",
-    accent: "#1e40af",
-  };
-
   return (
     <View style={styles.container}>
-      <Text style={[styles.label, { color: palette.text }]}>{label}</Text>
+      <Text style={styles.label}>{label}</Text>
       <View style={styles.previewRow}>
-        <View
-          style={[
-            styles.previewContainer,
-            { backgroundColor: palette.surface, borderColor: palette.border },
-          ]}
-        >
+        <View style={styles.previewContainer}>
           {value ? (
             <Image source={{ uri: value }} resizeMode="contain" style={styles.previewImage} />
           ) : (
@@ -69,27 +123,14 @@ export function LogoPicker({ label = "Company logo", value, onChange }: LogoPick
           )}
         </View>
         <View style={styles.actions}>
-          <Pressable
-            style={[
-              styles.button,
-              styles.primaryButton,
-              { backgroundColor: palette.accent, borderColor: palette.accent },
-            ]}
-            onPress={handlePick}
-          >
+          <Pressable style={[styles.button, styles.primaryButton]} onPress={handlePick}>
             <Text style={[styles.buttonText, styles.primaryButtonText]}>
               {value ? "Replace logo" : "Upload logo"}
             </Text>
           </Pressable>
           {value ? (
-            <Pressable
-              style={[
-                styles.button,
-                { backgroundColor: palette.surface, borderColor: palette.border },
-              ]}
-              onPress={handleRemove}
-            >
-              <Text style={[styles.buttonText, { color: palette.text }]}>Remove logo</Text>
+            <Pressable style={[styles.button, styles.secondaryButton]} onPress={handleRemove}>
+              <Text style={[styles.buttonText, styles.secondaryButtonText]}>Remove logo</Text>
             </Pressable>
           ) : null}
         </View>
@@ -97,57 +138,5 @@ export function LogoPicker({ label = "Company logo", value, onChange }: LogoPick
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    gap: 8,
-  },
-  label: {
-    fontSize: 16,
-    fontWeight: "600",
-  },
-  previewRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 16,
-  },
-  previewContainer: {
-    width: 88,
-    height: 88,
-    borderRadius: 18,
-    borderWidth: 1,
-    alignItems: "center",
-    justifyContent: "center",
-    overflow: "hidden",
-  },
-  previewImage: {
-    width: "100%",
-    height: "100%",
-  },
-  placeholderLogo: {
-    opacity: 0.7,
-  },
-  actions: {
-    flex: 1,
-    gap: 8,
-  },
-  button: {
-    paddingVertical: 10,
-    paddingHorizontal: 14,
-    borderRadius: 12,
-    borderWidth: 1,
-  },
-  buttonText: {
-    textAlign: "center",
-    fontWeight: "600",
-  },
-  primaryButton: {
-    backgroundColor: "#1e40af",
-    borderColor: "#1e40af",
-  },
-  primaryButtonText: {
-    color: "#fff",
-  },
-});
 
 export default LogoPicker;

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren, useMemo } from "react";
 import { StyleProp, StyleSheet, Text, TextStyle, View, ViewStyle } from "react-native";
-import { useTheme } from "../../theme";
+import { Theme } from "../../theme";
+import { useThemeContext } from "../../theme/ThemeProvider";
 
 export type BadgeTone = "info" | "warning" | "success" | "danger" | "muted";
 
@@ -11,7 +12,7 @@ export interface BadgeProps {
 }
 
 export function Badge({ children, style, textStyle }: PropsWithChildren<BadgeProps>) {
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   return (
@@ -21,7 +22,7 @@ export function Badge({ children, style, textStyle }: PropsWithChildren<BadgePro
   );
 }
 
-function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
+function createStyles(theme: Theme) {
   return StyleSheet.create({
     container: {
       alignSelf: "flex-start",

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -9,7 +9,8 @@ import {
   View,
   ViewStyle,
 } from "react-native";
-import { useTheme } from "../../theme";
+import { Theme } from "../../theme";
+import { useThemeContext } from "../../theme/ThemeProvider";
 
 export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
 
@@ -44,7 +45,7 @@ export function Button({
   contentStyle,
   accessibilityLabel,
 }: ButtonProps) {
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const isDisabled = disabled || loading;
 
@@ -84,7 +85,7 @@ export function Button({
   );
 }
 
-function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
+function createStyles(theme: Theme) {
   return StyleSheet.create({
     base: {
       borderRadius: theme.radii.lg,

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren, useMemo } from "react";
 import { Platform, StyleProp, StyleSheet, View, ViewStyle } from "react-native";
-import { useTheme } from "../../theme";
+import { Theme } from "../../theme";
+import { useThemeContext } from "../../theme/ThemeProvider";
 
 export interface CardProps {
   style?: StyleProp<ViewStyle>;
@@ -8,13 +9,13 @@ export interface CardProps {
 }
 
 export function Card({ children, style, elevated = true }: PropsWithChildren<CardProps>) {
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme, elevated), [theme, elevated]);
 
   return <View style={[styles.container, style]}>{children}</View>;
 }
 
-function createStyles(theme: ReturnType<typeof useTheme>["theme"], elevated: boolean) {
+function createStyles(theme: Theme, elevated: boolean) {
   const shadow: ViewStyle = elevated
     ? {
         shadowColor: theme.colors.overlay,

--- a/components/ui/FAB.tsx
+++ b/components/ui/FAB.tsx
@@ -1,6 +1,7 @@
 import { useMemo, type ReactNode } from "react";
 import { Platform, Pressable, StyleProp, StyleSheet, ViewStyle } from "react-native";
-import { useTheme } from "../../theme";
+import { Theme } from "../../theme";
+import { useThemeContext } from "../../theme/ThemeProvider";
 
 type FABPalette = "auto" | "primary" | "highlight";
 
@@ -13,10 +14,10 @@ export interface FABProps {
 }
 
 export function FAB({ icon, onPress, accessibilityLabel, palette = "auto", style }: FABProps) {
-  const { theme, mode } = useTheme();
+  const { theme, isDark } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const resolvedPalette =
-    palette === "auto" ? (mode === "dark" ? "highlight" : "primary") : palette;
+    palette === "auto" ? (isDark ? "highlight" : "primary") : palette;
 
   return (
     <Pressable
@@ -35,7 +36,7 @@ export function FAB({ icon, onPress, accessibilityLabel, palette = "auto", style
   );
 }
 
-function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
+function createStyles(theme: Theme) {
   return StyleSheet.create({
     base: {
       alignItems: "center",

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -10,7 +10,8 @@ import {
   View,
   ViewStyle,
 } from "react-native";
-import { useTheme } from "../../theme";
+import { Theme } from "../../theme";
+import { useThemeContext } from "../../theme/ThemeProvider";
 
 export interface InputProps extends TextInputProps {
   label?: string;
@@ -36,7 +37,7 @@ export const Input = forwardRef<TextInput, InputProps>(function Input(
   }: InputProps,
   ref: ForwardedRef<TextInput>,
 ) {
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const [isFocused, setFocused] = useState(false);
 
@@ -90,7 +91,7 @@ export const Input = forwardRef<TextInput, InputProps>(function Input(
   );
 });
 
-function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
+function createStyles(theme: Theme) {
   return StyleSheet.create({
     container: {
       gap: theme.spacing.xs,

--- a/components/ui/ListItem.tsx
+++ b/components/ui/ListItem.tsx
@@ -1,6 +1,7 @@
 import { useMemo, type ReactNode } from "react";
 import { Pressable, StyleProp, StyleSheet, Text, TextStyle, View, ViewStyle } from "react-native";
-import { useTheme } from "../../theme";
+import { Theme } from "../../theme";
+import { useThemeContext } from "../../theme/ThemeProvider";
 
 export interface ListItemProps {
   title: string;
@@ -27,7 +28,7 @@ export function ListItem({
   subtitleStyle,
   amountStyle,
 }: ListItemProps) {
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
   let resolvedRightContent: ReactNode | null = rightContent ?? null;
   if (!resolvedRightContent) {
@@ -64,7 +65,7 @@ export function ListItem({
   );
 }
 
-function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
+function createStyles(theme: Theme) {
   return StyleSheet.create({
     container: {
       flexDirection: "row",

--- a/components/ui/Typography.tsx
+++ b/components/ui/Typography.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren, useMemo } from "react";
 import { StyleProp, StyleSheet, Text, TextProps, TextStyle } from "react-native";
-import { useTheme, type Theme } from "../../theme";
+import { Theme } from "../../theme";
+import { useThemeContext } from "../../theme/ThemeProvider";
 
 type TypographyProps = TextProps & {
   style?: StyleProp<TextStyle>;
@@ -30,7 +31,7 @@ function createStyles(theme: Theme) {
 }
 
 export function Title({ style, children, ...props }: PropsWithChildren<TypographyProps>) {
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   return (
@@ -41,7 +42,7 @@ export function Title({ style, children, ...props }: PropsWithChildren<Typograph
 }
 
 export function Subtitle({ style, children, ...props }: PropsWithChildren<TypographyProps>) {
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   return (
@@ -52,7 +53,7 @@ export function Subtitle({ style, children, ...props }: PropsWithChildren<Typogr
 }
 
 export function Body({ style, children, ...props }: PropsWithChildren<TypographyProps>) {
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   return (

--- a/theme/ThemeProvider.tsx
+++ b/theme/ThemeProvider.tsx
@@ -1,0 +1,54 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { useColorScheme } from "react-native";
+import { dark, light, type Theme, type ThemeMode } from "./index";
+
+export type ThemeContextValue = {
+  theme: Theme;
+  isDark: boolean;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: light,
+  isDark: false,
+  toggleTheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const colorScheme = useColorScheme();
+  const [mode, setMode] = useState<ThemeMode>(colorScheme === "dark" ? "dark" : "light");
+
+  useEffect(() => {
+    if (colorScheme === "dark" || colorScheme === "light") {
+      setMode(colorScheme);
+    }
+  }, [colorScheme]);
+
+  const toggleTheme = useCallback(() => {
+    setMode((prev) => (prev === "dark" ? "light" : "dark"));
+  }, []);
+
+  const value = useMemo<ThemeContextValue>(() => {
+    const theme = mode === "dark" ? dark : light;
+
+    return {
+      theme,
+      isDark: mode === "dark",
+      toggleTheme,
+    };
+  }, [mode, toggleTheme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useThemeContext() {
+  return useContext(ThemeContext);
+}

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -1,4 +1,3 @@
-import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
 import { Appearance, Platform } from "react-native";
 
 export type ThemeSpacing = {
@@ -122,48 +121,6 @@ export const dark: Theme = {
   spacing,
   radii,
 };
-
-type ThemeContextValue = {
-  mode: ThemeMode;
-  theme: Theme;
-  setMode: (mode: ThemeMode) => void;
-  toggleMode: () => void;
-};
-
-const defaultThemeContext: ThemeContextValue = {
-  mode: "light",
-  theme: light,
-  setMode: () => {},
-  toggleMode: () => {},
-};
-
-export const ThemeContext = createContext<ThemeContextValue>(defaultThemeContext);
-
-export type ThemeProviderProps = {
-  children: ReactNode;
-  defaultMode?: ThemeMode;
-};
-
-export function ThemeProvider({ children, defaultMode = "light" }: ThemeProviderProps) {
-  const [mode, setMode] = useState<ThemeMode>(defaultMode);
-
-  const value = useMemo<ThemeContextValue>(() => {
-    const theme = mode === "light" ? light : dark;
-
-    return {
-      mode,
-      theme,
-      setMode,
-      toggleMode: () => setMode((prev) => (prev === "light" ? "dark" : "light")),
-    };
-  }, [mode]);
-
-  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
-}
-
-export function useTheme() {
-  return useContext(ThemeContext);
-}
 
 export function cardShadow(
   depth: number = 12,


### PR DESCRIPTION
## Summary
- add a new ThemeProvider that follows the system color scheme, exposes a toggle, and returns the active palette
- wrap the application layout in the new provider and update banners/tab chrome to read theme colors
- switch screens and UI components to use the new hook and add a temporary light/dark toggle button in settings

## Testing
- npm test -- --runTestsByPath __tests__/home.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de81c9ca988323b3df8bca357c8d2a