### PR TITLE
Fix preview shadow import and harden estimate deletion cleanup

### DIFF
--- a/app/(tabs)/estimates/[id].tsx
+++ b/app/(tabs)/estimates/[id].tsx
@@ -57,7 +57,7 @@ import {
   Title,
   type BadgeTone,
 } from "../../../components/ui";
-import { Theme } from "../../../theme";
+import { Theme, cardShadow } from "../../../theme";
 import { useThemeContext } from "../../../theme/ThemeProvider";
 import type { EstimateListItem } from "./index";
 import { v4 as uuidv4 } from "uuid";
@@ -1552,9 +1552,9 @@ export default function EditEstimateScreen() {
 
               await Promise.all(
                 photoRows.map(async (photo) => {
-                  await deleteLocalPhoto(
-                    photo.local_uri ?? deriveLocalPhotoUri(photo.id, photo.uri) ?? undefined,
-                  );
+                  const fallbackLocalUri =
+                    photo.local_uri ?? (photo.uri ? deriveLocalPhotoUri(photo.id, photo.uri) : null);
+                  await deleteLocalPhoto(fallbackLocalUri ?? undefined);
                   await queueChange("photos", "delete", { id: photo.id });
                 }),
               );


### PR DESCRIPTION
## Summary
- import the `cardShadow` helper into the estimate edit screen so the preview renders without runtime errors
- guard photo cleanup during estimate deletion to avoid crashes when photo URIs are missing

## Testing
- npm test -- --watchAll=false *(fails: __tests__/editEstimateItems.test.tsx times out at 5000 ms)*

------
https://chatgpt.com/codex/tasks/task_e_68de8b55f4288323a81be91a961471d5