### PR TITLE
Add shared delete confirmation helper for customer and estimate screens

### DIFF
--- a/lib/confirmDelete.ts
+++ b/lib/confirmDelete.ts
@@ -1,0 +1,26 @@
+import { Alert, Platform } from "react-native";
+
+export function confirmDelete(
+  title: string,
+  message: string,
+  onConfirm: () => void | Promise<void>,
+): void {
+  if (Platform.OS === "web") {
+    const promptMessage = message ? `${title}\n\n${message}` : title;
+    if (typeof window !== "undefined" && window.confirm(promptMessage)) {
+      void onConfirm();
+    }
+    return;
+  }
+
+  Alert.alert(title, message, [
+    { text: "Cancel", style: "cancel" },
+    {
+      text: "Delete",
+      style: "destructive",
+      onPress: () => {
+        void onConfirm();
+      },
+    },
+  ]);
+}


### PR DESCRIPTION
## Summary
- add a confirmDelete utility that supports web and native confirmations
- require the new helper when deleting customers or estimates so the destructive logic only runs after approval

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dea128e18c8323942739b553a77768