### PR TITLE
Refactor estimate creation flow

### DIFF
--- a/app/(tabs)/estimates/[id].tsx
+++ b/app/(tabs)/estimates/[id].tsx
@@ -436,6 +436,9 @@ export default function EditEstimateScreen() {
     const isoDate = estimateDate ? new Date(estimateDate).toISOString() : estimate.date;
 
     const trimmedNotes = notes.trim();
+    const billingAddress =
+      estimate.billing_address ?? customerContact?.address ?? estimate.customer_address ?? null;
+    const jobAddress = estimate.job_address ?? billingAddress ?? null;
 
     return {
       estimate: {
@@ -448,11 +451,16 @@ export default function EditEstimateScreen() {
         laborTotal: totals.laborTotal,
         taxTotal: totals.taxTotal,
         subtotal: totals.subtotal,
+        laborHours: totals.laborHours,
+        laborRate: totals.laborRate,
+        billingAddress,
+        jobAddress,
+        jobDetails: trimmedNotes ? trimmedNotes : null,
         customer: {
           name: customerContact?.name ?? estimate.customer_name ?? "Customer",
           email: customerContact?.email ?? estimate.customer_email ?? null,
           phone: customerContact?.phone ?? estimate.customer_phone ?? null,
-          address: customerContact?.address ?? estimate.customer_address ?? null,
+          address: billingAddress,
         },
       },
       items: items.map((item) => ({
@@ -1376,6 +1384,7 @@ export default function EditEstimateScreen() {
         const db = await openDB();
         const rows = await db.getAllAsync<EstimateListItem>(
           `SELECT e.id, e.user_id, e.customer_id, e.date, e.total, e.material_total, e.labor_hours, e.labor_rate, e.labor_total, e.subtotal, e.tax_rate, e.tax_total, e.notes, e.status, e.version, e.updated_at, e.deleted_at,
+                  e.billing_address, e.job_address, e.job_details,
                   c.name AS customer_name,
                   c.email AS customer_email,
                   c.phone AS customer_phone,

--- a/app/(tabs)/estimates/index.tsx
+++ b/app/(tabs)/estimates/index.tsx
@@ -1,14 +1,7 @@
 import { Feather } from "@expo/vector-icons";
 import { router } from "expo-router";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import {
-  ActivityIndicator,
-  FlatList,
-  RefreshControl,
-  StyleSheet,
-  Text,
-  View,
-} from "react-native";
+import { ActivityIndicator, FlatList, RefreshControl, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Badge, Button, Card, FAB, Input, ListItem } from "../../../components/ui";
 import { openDB } from "../../../lib/sqlite";
@@ -33,6 +26,9 @@ type EstimateListItem = {
   tax_rate: number | null;
   tax_total: number | null;
   notes: string | null;
+  billing_address: string | null;
+  job_address: string | null;
+  job_details: string | null;
   status: string | null;
   version: number | null;
   updated_at: string;
@@ -105,6 +101,7 @@ export default function EstimatesScreen() {
       const rows = await db.getAllAsync<EstimateListItem>(
         `SELECT e.id, e.user_id, e.customer_id, e.date, e.total, e.notes, e.status, e.version, e.updated_at, e.deleted_at,
                 e.material_total, e.labor_hours, e.labor_rate, e.labor_total, e.subtotal, e.tax_rate, e.tax_total,
+                e.billing_address, e.job_address, e.job_details,
                 c.name AS customer_name,
                 c.email AS customer_email,
                 c.phone AS customer_phone,
@@ -237,20 +234,20 @@ export default function EstimatesScreen() {
                   {STATUS_FILTERS.map((filter) => {
                     const isSelected = statusFilter === filter.key;
                     return (
-                    <Button
-                      key={filter.key}
-                      label={filter.label}
-                      variant={isSelected ? "primary" : "ghost"}
-                      alignment="inline"
-                      onPress={() => setStatusFilter(filter.key)}
-                      style={[styles.filterButton, isSelected ? styles.filterButtonActive : null]}
-                      textStyle={[styles.filterButtonLabel]}
-                      accessibilityLabel={`Filter estimates by status: ${filter.label}`}
-                    />
-                  );
-                })}
-              </View>
-            </Card>
+                      <Button
+                        key={filter.key}
+                        label={filter.label}
+                        variant={isSelected ? "primary" : "ghost"}
+                        alignment="inline"
+                        onPress={() => setStatusFilter(filter.key)}
+                        style={[styles.filterButton, isSelected ? styles.filterButtonActive : null]}
+                        textStyle={[styles.filterButtonLabel]}
+                        accessibilityLabel={`Filter estimates by status: ${filter.label}`}
+                      />
+                    );
+                  })}
+                </View>
+              </Card>
               {loading ? (
                 <Card style={styles.messageCard}>
                   <View style={styles.loadingRow}>

--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -82,6 +82,9 @@ export async function initLocalDB(): Promise<void> {
       tax_rate REAL DEFAULT 0,
       tax_total REAL DEFAULT 0,
       notes TEXT,
+      billing_address TEXT,
+      job_address TEXT,
+      job_details TEXT,
       status TEXT DEFAULT 'draft',
       version INTEGER DEFAULT 1,
       updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
@@ -114,6 +117,15 @@ export async function initLocalDB(): Promise<void> {
   }
   if (!estimateColumns.some((column) => column.name === "tax_total")) {
     await db.execAsync("ALTER TABLE estimates ADD COLUMN tax_total REAL DEFAULT 0");
+  }
+  if (!estimateColumns.some((column) => column.name === "billing_address")) {
+    await db.execAsync("ALTER TABLE estimates ADD COLUMN billing_address TEXT");
+  }
+  if (!estimateColumns.some((column) => column.name === "job_address")) {
+    await db.execAsync("ALTER TABLE estimates ADD COLUMN job_address TEXT");
+  }
+  if (!estimateColumns.some((column) => column.name === "job_details")) {
+    await db.execAsync("ALTER TABLE estimates ADD COLUMN job_details TEXT");
   }
 
   // Estimate Items


### PR DESCRIPTION
## Summary
- Rework the new estimate screen into a single scrollable form with customer lookup/creation, billing and job address controls, job details, line items, labor inputs, photo attachments, and sticky footer actions.
- Persist billing/job addresses, job details, labor metrics, and attached photos when saving or sharing an estimate.
- Extend PDF rendering, the list/edit flows, and the local SQLite schema to surface the new address and job detail data.

## Testing
- npm run lint *(warnings: existing Prettier style issues elsewhere in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68deb20145748323af48c01c3a249b83