### PR TITLE
Remove expo-image-manipulator dependency for PDF generation

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -52,8 +52,3 @@ jest.mock("react-native/Libraries/Components/Touchable/TouchableOpacity", () => 
   return MockTouchableOpacity;
 });
 
-jest.mock("expo-image-manipulator", () => ({
-  __esModule: true,
-  manipulateAsync: jest.fn(async (uri: string) => ({ uri, base64: null })),
-  SaveFormat: { JPEG: "jpeg", PNG: "png" },
-}));

--- a/lib/pdf.ts
+++ b/lib/pdf.ts
@@ -1,7 +1,6 @@
 import { Platform } from "react-native";
 import * as Print from "expo-print";
 import * as FileSystem from "expo-file-system/legacy";
-import * as ImageManipulator from "expo-image-manipulator";
 
 const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL ?? "";
 const PHOTO_BUCKET = process.env.EXPO_PUBLIC_SUPABASE_STORAGE_BUCKET ?? "estimate-photos";
@@ -120,31 +119,6 @@ async function resolvePhotoSource(photo: EstimatePdfPhoto): Promise<string | nul
     const info = await FileSystem.getInfoAsync(candidate);
     if (!info.exists) {
       return null;
-    }
-
-    try {
-      const manipulated = await ImageManipulator.manipulateAsync(
-        candidate,
-        [{ resize: { width: 1200 } }],
-        {
-          compress: 0.7,
-          format: ImageManipulator.SaveFormat.JPEG,
-          base64: true,
-        },
-      );
-
-      if (manipulated.base64) {
-        return `data:image/jpeg;base64,${manipulated.base64}`;
-      }
-
-      if (manipulated.uri && manipulated.uri !== candidate) {
-        const fallback = await FileSystem.readAsStringAsync(manipulated.uri, {
-          encoding: FileSystem.EncodingType.Base64,
-        });
-        return `data:image/jpeg;base64,${fallback}`;
-      }
-    } catch (error) {
-      console.warn("Failed to optimize photo for PDF", error);
     }
 
     const base64 = await FileSystem.readAsStringAsync(candidate, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "expo-constants": "~18.0.9",
         "expo-file-system": "~19.0.16",
         "expo-haptics": "~15.0.7",
-        "expo-image-manipulator": "~12.0.5",
         "expo-image-picker": "~17.0.8",
         "expo-linking": "~8.0.8",
         "expo-print": "~15.0.7",
@@ -8332,27 +8331,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-6.0.0.tgz",
       "integrity": "sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-image-manipulator": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-12.0.5.tgz",
-      "integrity": "sha512-zJ8yINjckYw/yfoSuICt4yJ9xr112+W9e5QVXwK3nCAHr7sv45RQ5sxte0qppf594TPl+UoV6Tjim7WpoKipRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "expo-image-loader": "~4.7.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-image-manipulator/node_modules/expo-image-loader": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-4.7.0.tgz",
-      "integrity": "sha512-cx+MxxsAMGl9AiWnQUzrkJMJH4eNOGlu7XkLGnAXSJrRoIiciGaKqzeaD326IyCTV+Z1fXvIliSgNW+DscvD8g==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "expo-constants": "~18.0.9",
     "expo-file-system": "~19.0.16",
     "expo-haptics": "~15.0.7",
-    "expo-image-manipulator": "~12.0.5",
     "expo-image-picker": "~17.0.8",
     "expo-linking": "~8.0.8",
     "expo-print": "~15.0.7",


### PR DESCRIPTION
## Summary
- stop importing `expo-image-manipulator` in the PDF helper and fall back to reading photo assets directly so the web bundler no longer fails to resolve the native module
- remove the unused `expo-image-manipulator` dependency and its Jest mock now that the module is not referenced

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68debe09798883238f4f6adda89b8299