### PR TITLE
Add saved item management and markup-aware updates

### DIFF
--- a/__tests__/estimateMath.test.ts
+++ b/__tests__/estimateMath.test.ts
@@ -1,0 +1,40 @@
+import { applyMarkup, calculateEstimateTotals } from "../lib/estimateMath";
+
+describe("applyMarkup", () => {
+  it("applies percentage markup correctly", () => {
+    const result = applyMarkup(100, { mode: "percentage", value: 10 }, { apply: true });
+    expect(result).toEqual({ base: 100, markupAmount: 10, total: 110 });
+  });
+
+  it("applies flat markup correctly", () => {
+    const result = applyMarkup(80, { mode: "flat", value: 25 }, { apply: true });
+    expect(result).toEqual({ base: 80, markupAmount: 25, total: 105 });
+  });
+
+  it("skips markup when apply is false", () => {
+    const result = applyMarkup(120, { mode: "percentage", value: 15 }, { apply: false });
+    expect(result).toEqual({ base: 120, markupAmount: 0, total: 120 });
+  });
+});
+
+describe("calculateEstimateTotals", () => {
+  it("combines material and labor markup into the totals", () => {
+    const totals = calculateEstimateTotals({
+      materialLineItems: [
+        { baseTotal: 100, applyMarkup: true },
+        { baseTotal: 50, applyMarkup: false },
+      ],
+      materialMarkup: { mode: "percentage", value: 10 },
+      laborHours: 5,
+      laborRate: 40,
+      laborMarkup: { mode: "flat", value: 25 },
+      taxRate: 8,
+    });
+
+    expect(totals.materialTotal).toBe(160);
+    expect(totals.laborTotal).toBe(225);
+    expect(totals.subtotal).toBe(385);
+    expect(totals.taxTotal).toBeCloseTo(30.8, 5);
+    expect(totals.grandTotal).toBeCloseTo(415.8, 5);
+  });
+});

--- a/app/(tabs)/estimates/_layout.tsx
+++ b/app/(tabs)/estimates/_layout.tsx
@@ -9,6 +9,7 @@ export default function EstimatesLayout() {
         <Stack.Screen name="new" options={{ title: "New Estimate", presentation: "modal" }} />
         <Stack.Screen name="[id]" options={{ title: "Edit Estimate", presentation: "modal" }} />
         <Stack.Screen name="item-editor" options={{ title: "Item" }} />
+        <Stack.Screen name="saved-items" options={{ title: "Saved Items" }} />
       </Stack>
     </ItemEditorProvider>
   );

--- a/app/(tabs)/estimates/index.tsx
+++ b/app/(tabs)/estimates/index.tsx
@@ -247,7 +247,16 @@ export default function EstimatesScreen() {
                     );
                   })}
                 </View>
-              </Card>
+                </Card>
+              <View style={styles.utilitiesRow}>
+                <Button
+                  label="Manage saved items"
+                  variant="secondary"
+                  alignment="inline"
+                  onPress={() => router.push("/(tabs)/estimates/saved-items")}
+                  leadingIcon={<Feather name="bookmark" size={18} color={theme.colors.primary} />}
+                />
+              </View>
               {loading ? (
                 <Card style={styles.messageCard}>
                   <View style={styles.loadingRow}>
@@ -342,6 +351,10 @@ function createStyles(theme: Theme) {
     },
     titleBlock: {
       gap: theme.spacing.sm,
+    },
+    utilitiesRow: {
+      flexDirection: "row",
+      justifyContent: "flex-start",
     },
     screenTitle: {
       fontSize: 28,

--- a/app/(tabs)/estimates/item-editor.tsx
+++ b/app/(tabs)/estimates/item-editor.tsx
@@ -116,9 +116,12 @@ export default function EstimateItemEditorScreen() {
           initialValue={config.initialValue}
           initialTemplateId={config.initialTemplateId ?? null}
           templates={templates}
+          materialMarkupValue={config.materialMarkupValue}
+          materialMarkupMode={config.materialMarkupMode}
           onSubmit={handleSubmit}
           onCancel={handleCancel}
           submitLabel={config.submitLabel}
+          showLibraryToggle={config.showLibraryToggle ?? true}
         />
       </Card>
     </ScrollView>

--- a/app/(tabs)/estimates/saved-items.tsx
+++ b/app/(tabs)/estimates/saved-items.tsx
@@ -1,0 +1,483 @@
+import { useFocusEffect } from "expo-router";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Feather } from "@expo/vector-icons";
+import { Button, Card, Input } from "../../../components/ui";
+import { useAuth } from "../../../context/AuthContext";
+import {
+  listSavedItems,
+  softDeleteSavedItem,
+  upsertSavedItem,
+  type SavedItemRecord,
+} from "../../../lib/savedItems";
+import { Theme } from "../../../theme";
+import { useThemeContext } from "../../../theme/ThemeProvider";
+
+function formatCurrency(amount: number): string {
+  const value = Number.isFinite(amount) ? amount : 0;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+  }).format(value);
+}
+
+type EditorState = {
+  id: string | null;
+  name: string;
+  quantityText: string;
+  unitPriceText: string;
+  markupApplicable: boolean;
+};
+
+function createEmptyEditor(): EditorState {
+  return {
+    id: null,
+    name: "",
+    quantityText: "1",
+    unitPriceText: "0.00",
+    markupApplicable: true,
+  };
+}
+
+function parseQuantity(value: string): number {
+  const normalized = value.replace(/[^0-9]/g, "");
+  const parsed = parseInt(normalized, 10);
+  if (!Number.isFinite(parsed)) {
+    return 0;
+  }
+  return Math.max(1, parsed);
+}
+
+function parseCurrencyInput(value: string): number {
+  const normalized = value.replace(/[^0-9.]/g, "");
+  const parsed = parseFloat(normalized);
+  if (!Number.isFinite(parsed)) {
+    return 0;
+  }
+  return Math.max(0, Math.round(parsed * 100) / 100);
+}
+
+function formatUnitPriceInput(value: number | null | undefined): string {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return "0.00";
+  }
+  return (Math.round(value * 100) / 100).toFixed(2);
+}
+
+export default function SavedItemsScreen() {
+  const { user } = useAuth();
+  const { theme } = useThemeContext();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const [savedItems, setSavedItems] = useState<SavedItemRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editor, setEditor] = useState<EditorState | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const userId = user?.id ?? null;
+
+  const loadSavedItems = useCallback(async () => {
+    if (!userId) {
+      setSavedItems([]);
+      return;
+    }
+
+    try {
+      const records = await listSavedItems(userId);
+      setSavedItems(records);
+    } catch (error) {
+      console.error("Failed to load saved items", error);
+      Alert.alert(
+        "Error",
+        "We couldn't load your saved items. Pull down to refresh once you're back online.",
+      );
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    let isMounted = true;
+    (async () => {
+      setLoading(true);
+      await loadSavedItems();
+      if (isMounted) {
+        setLoading(false);
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [loadSavedItems]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!userId) {
+        return;
+      }
+
+      loadSavedItems().catch((error) => {
+        console.error("Failed to refresh saved items on focus", error);
+      });
+    }, [loadSavedItems, userId]),
+  );
+
+  const beginCreate = () => {
+    setEditor(createEmptyEditor());
+  };
+
+  const beginEdit = (item: SavedItemRecord) => {
+    setEditor({
+      id: item.id,
+      name: item.name,
+      quantityText: String(item.default_quantity ?? 1),
+      unitPriceText: formatUnitPriceInput(item.default_unit_price ?? 0),
+      markupApplicable: item.default_markup_applicable !== 0,
+    });
+  };
+
+  const handleCancelEdit = () => {
+    setEditor(null);
+  };
+
+  const handleSubmit = async () => {
+    if (!editor) {
+      return;
+    }
+
+    const trimmedName = editor.name.trim();
+    if (!trimmedName) {
+      Alert.alert("Validation", "Please provide a name for this saved item.");
+      return;
+    }
+
+    const quantity = parseQuantity(editor.quantityText);
+    if (quantity <= 0) {
+      Alert.alert("Validation", "Quantity must be at least 1.");
+      return;
+    }
+
+    const unitPrice = parseCurrencyInput(editor.unitPriceText);
+
+    if (!userId) {
+      Alert.alert("Authentication", "You need to be signed in to manage saved items.");
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      await upsertSavedItem({
+        id: editor.id ?? undefined,
+        userId,
+        name: trimmedName,
+        unitPrice,
+        defaultQuantity: quantity,
+        markupApplicable: editor.markupApplicable,
+      });
+      await loadSavedItems();
+      setEditor(null);
+    } catch (error) {
+      console.error("Failed to save item template", error);
+      Alert.alert("Error", "We couldn't save this item. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const confirmDelete = (item: SavedItemRecord) => {
+    Alert.alert(
+      "Delete saved item",
+      `Are you sure you want to delete "${item.name}"? You can save it again later if needed.`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete",
+          style: "destructive",
+          onPress: async () => {
+            try {
+              await softDeleteSavedItem(item.id);
+              await loadSavedItems();
+            } catch (error) {
+              console.error("Failed to delete saved item", error);
+              Alert.alert("Error", "We couldn't delete this saved item. Please try again.");
+            }
+          },
+        },
+      ],
+    );
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.headerBlock}>
+          <Text style={styles.title}>Saved items</Text>
+          <Text style={styles.subtitle}>
+            Create reusable material templates so you can quickly add them to any estimate.
+          </Text>
+          <Button
+            label={editor ? "Add another saved item" : "Add saved item"}
+            onPress={beginCreate}
+            alignment="inline"
+            leadingIcon={<Feather name="plus" size={18} color={theme.colors.surface} />}
+          />
+        </View>
+
+        {editor ? (
+          <Card style={styles.editorCard}>
+            <Text style={styles.editorTitle}>{editor.id ? "Edit saved item" : "New saved item"}</Text>
+            <View style={styles.editorForm}>
+              <Input
+                label="Name"
+                placeholder="Example: Premium vinyl flooring"
+                value={editor.name}
+                onChangeText={(text) => setEditor((prev) => (prev ? { ...prev, name: text } : prev))}
+              />
+              <View style={styles.row}>
+                <View style={styles.rowField}>
+                  <Input
+                    label="Default quantity"
+                    placeholder="1"
+                    value={editor.quantityText}
+                    onChangeText={(text) =>
+                      setEditor((prev) => (prev ? { ...prev, quantityText: text } : prev))
+                    }
+                    keyboardType="number-pad"
+                  />
+                </View>
+                <View style={styles.rowField}>
+                  <Input
+                    label="Default unit price"
+                    placeholder="0.00"
+                    value={editor.unitPriceText}
+                    onChangeText={(text) =>
+                      setEditor((prev) => (prev ? { ...prev, unitPriceText: text } : prev))
+                    }
+                    keyboardType="decimal-pad"
+                  />
+                </View>
+              </View>
+              <View style={styles.toggleRow}>
+                <View style={styles.toggleCopy}>
+                  <Text style={styles.toggleTitle}>Apply markup by default</Text>
+                  <Text style={styles.toggleHint}>
+                    When enabled, this item will use your material markup when added to an estimate.
+                  </Text>
+                </View>
+                <Switch
+                  value={editor.markupApplicable}
+                  onValueChange={(value) =>
+                    setEditor((prev) => (prev ? { ...prev, markupApplicable: value } : prev))
+                  }
+                  trackColor={{ false: theme.colors.border, true: theme.colors.primarySoft }}
+                  thumbColor={editor.markupApplicable ? theme.colors.primary : undefined}
+                />
+              </View>
+              <View style={styles.editorActions}>
+                <Button
+                  label="Cancel"
+                  onPress={handleCancelEdit}
+                  variant="secondary"
+                  alignment="inline"
+                  disabled={submitting}
+                />
+                <Button
+                  label={editor.id ? "Update saved item" : "Save saved item"}
+                  onPress={handleSubmit}
+                  loading={submitting}
+                  disabled={submitting}
+                  alignment="inline"
+                />
+              </View>
+            </View>
+          </Card>
+        ) : null}
+
+        <View style={styles.listSection}>
+          {loading ? (
+            <Card style={styles.messageCard}>
+              <View style={styles.loadingRow}>
+                <ActivityIndicator color={theme.colors.primary} />
+                <Text style={styles.messageText}>Loading saved items…</Text>
+              </View>
+            </Card>
+          ) : savedItems.length === 0 ? (
+            <Card style={styles.messageCard}>
+              <Text style={styles.messageText}>
+                You haven't saved any items yet. Add one above to start building your library.
+              </Text>
+            </Card>
+          ) : (
+            savedItems.map((item) => (
+              <Card key={item.id} style={styles.itemCard}>
+                <View style={styles.itemHeader}>
+                  <Text style={styles.itemName}>{item.name}</Text>
+                  <Text style={styles.itemMeta}>
+                    {formatCurrency(item.default_unit_price ?? 0)} • Qty {item.default_quantity ?? 1}
+                  </Text>
+                </View>
+                <Text style={styles.itemMarkup}>
+                  Markup {item.default_markup_applicable !== 0 ? "enabled" : "disabled"}
+                </Text>
+                <View style={styles.itemActions}>
+                  <Button
+                    label="Edit"
+                    variant="secondary"
+                    alignment="inline"
+                    onPress={() => beginEdit(item)}
+                  />
+                  <Button
+                    label="Delete"
+                    variant="danger"
+                    alignment="inline"
+                    onPress={() => confirmDelete(item)}
+                  />
+                </View>
+              </Card>
+            ))
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    safeArea: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    scroll: {
+      flex: 1,
+    },
+    content: {
+      padding: theme.spacing.xl,
+      gap: theme.spacing.xl,
+    },
+    headerBlock: {
+      gap: theme.spacing.md,
+    },
+    title: {
+      fontSize: 28,
+      fontWeight: "700",
+      color: theme.colors.primaryText,
+    },
+    subtitle: {
+      fontSize: 15,
+      color: theme.colors.textMuted,
+      lineHeight: 22,
+    },
+    editorCard: {
+      padding: theme.spacing.xl,
+      gap: theme.spacing.lg,
+      backgroundColor: theme.colors.surface,
+      borderRadius: theme.radii.lg,
+    },
+    editorTitle: {
+      fontSize: 18,
+      fontWeight: "700",
+      color: theme.colors.primaryText,
+    },
+    editorForm: {
+      gap: theme.spacing.lg,
+    },
+    row: {
+      flexDirection: "row",
+      gap: theme.spacing.lg,
+      flexWrap: "wrap",
+    },
+    rowField: {
+      flex: 1,
+      minWidth: 160,
+    },
+    toggleRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      gap: theme.spacing.md,
+    },
+    toggleCopy: {
+      flex: 1,
+      gap: theme.spacing.xs,
+    },
+    toggleTitle: {
+      fontSize: 16,
+      fontWeight: "600",
+      color: theme.colors.primaryText,
+    },
+    toggleHint: {
+      fontSize: 13,
+      color: theme.colors.textMuted,
+      lineHeight: 18,
+    },
+    editorActions: {
+      flexDirection: "row",
+      gap: theme.spacing.md,
+      justifyContent: "flex-end",
+      flexWrap: "wrap",
+    },
+    listSection: {
+      gap: theme.spacing.lg,
+    },
+    messageCard: {
+      padding: theme.spacing.xl,
+      borderRadius: theme.radii.lg,
+      backgroundColor: theme.colors.surface,
+    },
+    messageText: {
+      fontSize: 15,
+      color: theme.colors.text,
+      lineHeight: 22,
+    },
+    loadingRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing.md,
+    },
+    itemCard: {
+      padding: theme.spacing.xl,
+      borderRadius: theme.radii.lg,
+      backgroundColor: theme.colors.surface,
+      gap: theme.spacing.md,
+    },
+    itemHeader: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "flex-start",
+    },
+    itemName: {
+      flex: 1,
+      fontSize: 17,
+      fontWeight: "600",
+      color: theme.colors.primaryText,
+    },
+    itemMeta: {
+      fontSize: 15,
+      color: theme.colors.textMuted,
+    },
+    itemMarkup: {
+      fontSize: 14,
+      color: theme.colors.textMuted,
+    },
+    itemActions: {
+      flexDirection: "row",
+      gap: theme.spacing.md,
+      flexWrap: "wrap",
+      justifyContent: "flex-end",
+    },
+  });
+}
+

--- a/context/ItemEditorContext.tsx
+++ b/context/ItemEditorContext.tsx
@@ -6,7 +6,11 @@ import React, {
   useState,
   type PropsWithChildren,
 } from "react";
-import type { EstimateItemFormSubmit, EstimateItemTemplate } from "../components/EstimateItemForm";
+import type {
+  EstimateItemFormSubmit,
+  EstimateItemTemplate,
+} from "../components/EstimateItemForm";
+import type { MarkupMode } from "../lib/estimateMath";
 
 export type ItemEditorConfig = {
   title: string;
@@ -15,9 +19,13 @@ export type ItemEditorConfig = {
     description: string;
     quantity: number;
     unit_price: number;
+    apply_markup?: boolean;
   };
   initialTemplateId?: string | null;
   templates?: EstimateItemTemplate[] | (() => EstimateItemTemplate[]);
+  materialMarkupValue: number;
+  materialMarkupMode: MarkupMode;
+  showLibraryToggle?: boolean;
   onSubmit: (payload: EstimateItemFormSubmit) => Promise<void> | void;
   onCancel?: () => void;
 };

--- a/context/SettingsContext.tsx
+++ b/context/SettingsContext.tsx
@@ -11,6 +11,7 @@ import {
   useState,
 } from "react";
 import * as Haptics from "expo-haptics";
+import type { MarkupMode } from "../lib/estimateMath";
 
 export type ThemePreference = "light" | "dark" | "system";
 
@@ -28,7 +29,9 @@ export interface CompanyProfile {
 export interface SettingsState {
   themePreference: ThemePreference;
   materialMarkup: number;
+  materialMarkupMode: MarkupMode;
   laborMarkup: number;
+  laborMarkupMode: MarkupMode;
   hourlyRate: number;
   taxRate: number;
   hapticsEnabled: boolean;
@@ -46,7 +49,9 @@ interface SettingsContextValue {
   resolvedTheme: "light" | "dark";
   setThemePreference: (preference: ThemePreference) => void;
   setMaterialMarkup: (value: number) => void;
+  setMaterialMarkupMode: (value: MarkupMode) => void;
   setLaborMarkup: (value: number) => void;
+  setLaborMarkupMode: (value: MarkupMode) => void;
   setHourlyRate: (value: number) => void;
   setTaxRate: (value: number) => void;
   setHapticsEnabled: (value: boolean) => void;
@@ -85,7 +90,9 @@ const DEFAULT_COMPANY_PROFILE: CompanyProfile = {
 const DEFAULT_SETTINGS: SettingsState = {
   themePreference: "system",
   materialMarkup: 15,
+  materialMarkupMode: "percentage",
   laborMarkup: 20,
+  laborMarkupMode: "percentage",
   hourlyRate: 85,
   taxRate: 8,
   hapticsEnabled: true,
@@ -217,9 +224,23 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     [updateSettings],
   );
 
+  const setMaterialMarkupMode = useCallback(
+    (mode: MarkupMode) => {
+      updateSettings({ materialMarkupMode: mode === "flat" ? "flat" : "percentage" });
+    },
+    [updateSettings],
+  );
+
   const setLaborMarkup = useCallback(
     (value: number) => {
       updateSettings({ laborMarkup: Number.isFinite(value) ? Math.max(0, value) : 0 });
+    },
+    [updateSettings],
+  );
+
+  const setLaborMarkupMode = useCallback(
+    (mode: MarkupMode) => {
+      updateSettings({ laborMarkupMode: mode === "flat" ? "flat" : "percentage" });
     },
     [updateSettings],
   );
@@ -342,7 +363,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       resolvedTheme,
       setThemePreference,
       setMaterialMarkup,
+      setMaterialMarkupMode,
       setLaborMarkup,
+      setLaborMarkupMode,
       setHourlyRate,
       setTaxRate,
       setHapticsEnabled,
@@ -364,7 +387,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setHapticIntensity,
       setHapticsEnabled,
       setLaborMarkup,
+      setLaborMarkupMode,
       setMaterialMarkup,
+      setMaterialMarkupMode,
       setHourlyRate,
       setTaxRate,
       setNotificationsEnabled,

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -40,7 +40,10 @@ type EstimateItem = {
   description: string;
   quantity: number;
   unit_price: number;
+  base_total: number | null;
   total: number;
+  apply_markup: number | null;
+  catalog_item_id: string | null;
   version: number | null;
   updated_at: string | null;
   deleted_at: string | null;
@@ -144,15 +147,18 @@ export async function bootstrapUserData(userId: string) {
 
   for (const item of estimateItems) {
     await db.runAsync(
-      `INSERT OR REPLACE INTO estimate_items (id, estimate_id, description, quantity, unit_price, total, version, updated_at, deleted_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT OR REPLACE INTO estimate_items (id, estimate_id, description, quantity, unit_price, base_total, total, apply_markup, catalog_item_id, version, updated_at, deleted_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         item.id,
         item.estimate_id,
         item.description,
         item.quantity,
         item.unit_price,
+        item.base_total ?? item.total ?? 0,
         item.total,
+        item.apply_markup ?? 1,
+        item.catalog_item_id ?? null,
         item.version ?? 1,
         item.updated_at ?? new Date().toISOString(),
         item.deleted_at,

--- a/supabase/migrations/20250301090000_create_saved_items.sql
+++ b/supabase/migrations/20250301090000_create_saved_items.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS public.saved_items (
   name text NOT NULL,
   default_quantity integer DEFAULT 1,
   default_unit_price numeric NOT NULL DEFAULT 0,
+  default_markup_applicable integer NOT NULL DEFAULT 1,
   version integer DEFAULT 1,
   updated_at timestamptz DEFAULT timezone('utc', now()),
   deleted_at timestamptz
@@ -15,7 +16,15 @@ CREATE INDEX IF NOT EXISTS saved_items_user_idx
   WHERE deleted_at IS NULL;
 
 -- Migrate legacy item_catalog rows if they exist
-INSERT INTO public.saved_items (id, user_id, name, default_quantity, default_unit_price, version, updated_at, deleted_at)
-SELECT id, user_id, description AS name, default_quantity, unit_price AS default_unit_price, version, updated_at, deleted_at
+INSERT INTO public.saved_items (id, user_id, name, default_quantity, default_unit_price, default_markup_applicable, version, updated_at, deleted_at)
+SELECT id,
+       user_id,
+       description AS name,
+       default_quantity,
+       unit_price AS default_unit_price,
+       1 AS default_markup_applicable,
+       version,
+       updated_at,
+       deleted_at
 FROM public.item_catalog
 ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary
- add a saved items management screen and expose navigation from the estimates tab
- ensure markup-aware totals persist across items, labor, and exports while syncing schema changes
- expand automated coverage for markup math and saved item workflows

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dec22e9e74832381d8cf9f089cb36f