### PR TITLE
Refactor customer management flow

### DIFF
--- a/app/(tabs)/estimates/[id].tsx
+++ b/app/(tabs)/estimates/[id].tsx
@@ -59,6 +59,12 @@ import {
   Title,
   type BadgeTone,
 } from "../../../components/ui";
+import type { CustomerRecord } from "../../../types/customers";
+
+type CustomerContact = Pick<
+  CustomerRecord,
+  "id" | "name" | "email" | "phone" | "address" | "notes"
+>;
 import { Theme } from "../../../theme";
 import { useThemeContext } from "../../../theme/ThemeProvider";
 import type { EstimateListItem } from "./index";
@@ -88,15 +94,6 @@ type PhotoRecord = {
   version: number | null;
   updated_at: string;
   deleted_at: string | null;
-};
-
-type CustomerRecord = {
-  id: string;
-  name: string;
-  email: string | null;
-  phone: string | null;
-  address: string | null;
-  notes: string | null;
 };
 
 type EstimateFormDraftState = {
@@ -225,7 +222,7 @@ export default function EditEstimateScreen() {
   const [pdfWorking, setPdfWorking] = useState(false);
   const [sending, setSending] = useState(false);
   const [sendSuccessMessage, setSendSuccessMessage] = useState<string | null>(null);
-  const [customerContact, setCustomerContact] = useState<CustomerRecord | null>(null);
+  const [customerContact, setCustomerContact] = useState<CustomerContact | null>(null);
 
   const statusLabel = useMemo(() => {
     const option = STATUS_OPTIONS.find((option) => option.value === status);
@@ -399,7 +396,7 @@ export default function EditEstimateScreen() {
     (async () => {
       try {
         const db = await openDB();
-        const rows = await db.getAllAsync<CustomerRecord>(
+        const rows = await db.getAllAsync<CustomerContact>(
           `SELECT id, name, email, phone, address, notes
            FROM customers
            WHERE id = ? AND deleted_at IS NULL

--- a/components/CustomerPicker.tsx
+++ b/components/CustomerPicker.tsx
@@ -7,6 +7,7 @@ import CustomerForm from "./CustomerForm";
 import { Theme } from "../theme";
 import { useThemeContext } from "../theme/ThemeProvider";
 import { Button, Card, Input } from "./ui";
+import type { CustomerRecord } from "../types/customers";
 
 type Customer = {
   id: string;
@@ -102,14 +103,29 @@ export default function CustomerPicker({ selectedCustomer, onSelect }: Props) {
   if (addingNew) {
     return (
       <CustomerForm
-        onSaved={(c) => {
+        onSaved={(customer: CustomerRecord) => {
           setAddingNew(false);
           setSearchQuery("");
-          loadCustomers().then(() => {
-            onSelect(c.id);
+
+          const mapped: Customer = {
+            id: customer.id,
+            name: customer.name,
+            phone: customer.phone,
+            email: customer.email,
+            address: customer.address,
+            notes: customer.notes,
+          };
+
+          setCustomers((prev) => {
+            const next = [mapped, ...prev.filter((row) => row.id !== mapped.id)];
+            return next.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
           });
+
+          onSelect(customer.id);
+          void loadCustomers();
         }}
         onCancel={() => setAddingNew(false)}
+        wrapInCard={false}
       />
     );
   }

--- a/types/customers.ts
+++ b/types/customers.ts
@@ -1,0 +1,12 @@
+export type CustomerRecord = {
+  id: string;
+  user_id: string;
+  name: string;
+  phone: string | null;
+  email: string | null;
+  address: string | null;
+  notes: string | null;
+  version: number;
+  updated_at: string;
+  deleted_at: string | null;
+};


### PR DESCRIPTION
## Summary
- centralize the customer record type and return full records from the shared customer form
- update the customers tab to filter instantly and keep selections in sync when adding or removing customers
- reuse the customer form in the estimate creation flow so new customers are persisted without leaving the screen

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfc3fa331083238da8e0471bdd4bf8