### PR TITLE
Align send preview with PDF details

### DIFF
--- a/__mocks__/expo-mail-composer.js
+++ b/__mocks__/expo-mail-composer.js
@@ -1,0 +1,11 @@
+export const MailComposerStatus = {
+  CANCELLED: "cancelled",
+  SAVED: "saved",
+  SENT: "sent",
+};
+
+export const isAvailableAsync = jest.fn().mockResolvedValue(true);
+
+export const composeAsync = jest
+  .fn()
+  .mockResolvedValue({ status: MailComposerStatus.SENT });

--- a/__tests__/editEstimateItems.test.tsx
+++ b/__tests__/editEstimateItems.test.tsx
@@ -93,7 +93,16 @@ jest.mock("../lib/storage", () => ({
 }));
 
 jest.mock("../lib/pdf", () => ({
-  renderEstimatePdf: jest.fn().mockResolvedValue({ html: "<html />", uri: "file:///estimate.pdf" }),
+  renderEstimatePdf: jest
+    .fn()
+    .mockResolvedValue({
+      html: "<html />",
+      uri: "file:///estimate.pdf",
+      fileName: "estimate.pdf",
+      storagePath: null,
+      publicUrl: null,
+    }),
+  uploadEstimatePdfToStorage: jest.fn().mockResolvedValue(null),
 }));
 
 jest.mock("expo-image-picker", () => ({

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "expo-haptics": "~15.0.7",
         "expo-image-picker": "~17.0.8",
         "expo-linking": "~8.0.8",
+        "expo-mail-composer": "^14.1.6",
         "expo-print": "~15.0.7",
         "expo-router": "~6.0.9",
         "expo-secure-store": "~15.0.7",
@@ -7277,6 +7278,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-mail-composer": {
+      "version": "14.1.6",
+      "resolved": "https://registry.npmjs.org/expo-mail-composer/-/expo-mail-composer-14.1.6.tgz",
+      "integrity": "sha512-xue+6ygCdqYMbIRbujZLWe/XlarYzxIKpMDxkFGw6yn6wMBGmc0WcNHL/77U9YbEejRlInlXbDC8m7VX7K96Zw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "expo-haptics": "~15.0.7",
     "expo-image-picker": "~17.0.8",
     "expo-linking": "~8.0.8",
+    "expo-mail-composer": "^14.1.6",
     "expo-print": "~15.0.7",
     "expo-router": "~6.0.9",
     "expo-secure-store": "~15.0.7",


### PR DESCRIPTION
## Summary
- align the send-to-client summary with the rendered PDF values and defaults
- normalize contact info and address placeholders to match the PDF output
- update the empty notes message so the preview mirrors the PDF copy

## Testing
- npm test -- --runInBand --detectOpenHandles __tests__/editEstimateItems.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dfd401155c83238dd4314de2061418