### PR TITLE
Finalize cleanup verification

### DIFF
--- a/__tests__/newEstimate.test.tsx
+++ b/__tests__/newEstimate.test.tsx
@@ -238,7 +238,6 @@ describe("NewEstimateScreen", () => {
     authState.session = null;
 
     const screen = render(<NewEstimateScreen />);
-    const { getByText, findByText } = screen;
 
     const jobTitleInput = await waitFor(() => {
       const inputs = screen.UNSAFE_getAllByType(TextInput);
@@ -251,7 +250,7 @@ describe("NewEstimateScreen", () => {
       return match;
     });
     fireEvent.changeText(jobTitleInput, "Landscaping");
-    const customerRow = await findByText("Acme Industries");
+    const customerRow = await screen.findByText("Acme Industries");
     const customerPressable = customerRow.parent?.parent ?? customerRow;
     fireEvent.press(customerPressable);
     await waitFor(() => {
@@ -288,7 +287,7 @@ describe("NewEstimateScreen", () => {
       await saveButton?.props.onPress?.();
     });
 
-    expect(await findByText("You need to be signed in to create a new estimate.")).toBeTruthy();
+    expect(await screen.findByText("You need to be signed in to create a new estimate.")).toBeTruthy();
     expect(alertSpy).toHaveBeenCalledWith(
       "Estimate",
       "You need to be signed in to create a new estimate.",

--- a/docs/final-cleanup-report.md
+++ b/docs/final-cleanup-report.md
@@ -1,0 +1,28 @@
+# Final Cleanup Verification
+
+## Navigation Flow
+- Auth stack redirects authenticated sessions directly into the tab navigator while unauthenticated users see the auth stack. 【F:app/(auth)/_layout.tsx†L5-L20】
+- The tab navigator exposes the Home, Customers, Estimates, and Settings routes with consistent theming and guards unauthenticated access. 【F:app/(tabs)/_layout.tsx†L8-L105】
+
+## Theming
+- Theme context dynamically tracks the system appearance and exposes a toggle for manual overrides. 【F:theme/ThemeProvider.tsx†L14-L41】
+- Each tab screen consumes themed styles so typography, surfaces, and controls respond to light/dark mode (example: Home screen). 【F:app/(tabs)/home.tsx†L235-L356】
+- Users can toggle between light and dark appearances from Settings, which applies the theme-aware styles app-wide. 【F:app/(tabs)/settings.tsx†L25-L314】
+
+## Offline Support
+- Local SQLite bootstrapping creates queue tables for pending mutations and normalizes schema for customers, estimates, items, photos, and saved items. 【F:lib/sqlite.ts†L39-L220】
+- Queue helpers persist pending changes, enabling later sync attempts. 【F:lib/sqlite.ts†L262-L289】
+- Root layout initializes the database and retries sync whenever the app becomes active to flush queued work. 【F:app/_layout.tsx†L131-L170】
+- Customer creation writes to SQLite immediately, queues the mutation, and triggers a sync when connectivity allows. 【F:components/CustomerForm.tsx†L41-L95】
+- Estimate creation/update mirrors the same pattern for estimates, line items, and photos, including retrying sync. 【F:app/(tabs)/estimates/new.tsx†L1120-L1335】
+
+## Soft Delete Coverage
+- Customer deletions soft-delete related estimates, line items, and photos, queue the mutations, and trigger sync. 【F:app/(tabs)/customers.tsx†L288-L382】
+- Estimate deletions apply soft deletes to the estimate, items, and photos before queuing sync work. 【F:app/(tabs)/estimates/[id].tsx†L2111-L2165】
+
+## Testing & Tooling
+- Updated the `requires an authenticated user` test to avoid unused references while keeping full behavior coverage. 【F:__tests__/newEstimate.test.tsx†L236-L297】
+- ESLint now passes without warnings, and the targeted Jest suite succeeds (`npm run lint`, `npm test -- --runTestsByPath __tests__/newEstimate.test.tsx`). 【c95fea†L1-L5】【4fe090†L1-L11】
+
+## Platform Scripts
+- `npm run web`, `npm run android`, and `npm run ios` start long-running Expo Metro servers; these were not executed in CI because the environment cannot host interactive Metro processes. Manual invocation remains unchanged from previous verification.


### PR DESCRIPTION
## Summary
- Update the new-estimate authentication regression test to use the screen helpers directly and eliminate unused references.
- Add a final cleanup verification report that captures navigation, theming, offline sync, and soft delete coverage.

## Testing
- npm run lint
- npm test -- --runTestsByPath __tests__/newEstimate.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dfdd8ec28883239a42544ac3537ecf