### PR TITLE
Improve type safety for estimate screens

### DIFF
--- a/types/expo-mail-composer.d.ts
+++ b/types/expo-mail-composer.d.ts
@@ -1,0 +1,23 @@
+declare module "expo-mail-composer" {
+  export type MailComposerOptions = {
+    subject?: string;
+    body?: string;
+    recipients?: string[];
+    attachments?: string[];
+    isHtml?: boolean;
+  };
+
+  export enum MailComposerStatus {
+    CANCELLED = "cancelled",
+    SAVED = "saved",
+    SENT = "sent",
+    UNKNOWN = "unknown",
+  }
+
+  export type MailComposerResult = {
+    status: MailComposerStatus;
+  };
+
+  export function composeAsync(options: MailComposerOptions): Promise<MailComposerResult>;
+  export function isAvailableAsync(): Promise<boolean>;
+}


### PR DESCRIPTION
## Summary
- align estimate record typings with the database schema and normalize SQLite rows before rendering the estimates list
- tighten edit estimate screen typing, normalize numeric totals, and type navigation params and FlatList usage
- add minimal TypeScript declarations for expo-mail-composer so TypeScript can resolve the module

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68dfe90cd890832389b20ba032ffcf22