### PR TITLE
Fix estimate item editor typings

### DIFF
--- a/app/(tabs)/estimates/[id].tsx
+++ b/app/(tabs)/estimates/[id].tsx
@@ -66,6 +66,7 @@ import {
   type BadgeTone,
 } from "../../../components/ui";
 import type { CustomerRecord } from "../../../types/customers";
+import type { EstimateItemRecord } from "../../../types/estimates";
 
 type CustomerContact = Pick<
   CustomerRecord,
@@ -75,21 +76,6 @@ import { Theme } from "../../../theme";
 import { useThemeContext } from "../../../theme/ThemeProvider";
 import type { EstimateListItem, EstimateRecord } from "./index";
 import { v4 as uuidv4 } from "uuid";
-
-type EstimateItemRecord = {
-  id: string;
-  estimate_id: string;
-  description: string;
-  quantity: number;
-  unit_price: number;
-  base_total: number;
-  total: number;
-  apply_markup: number;
-  catalog_item_id: string | null;
-  version: number;
-  updated_at: string;
-  deleted_at: string | null;
-};
 
 type PhotoRecord = {
   id: string;

--- a/app/(tabs)/estimates/item-editor.tsx
+++ b/app/(tabs)/estimates/item-editor.tsx
@@ -1,7 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useNavigation, useRouter } from "expo-router";
 import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from "react-native";
-import EstimateItemForm from "../../../components/EstimateItemForm";
+import EstimateItemForm, {
+  type EstimateItemFormSubmit,
+  type EstimateItemTemplate,
+} from "../../../components/EstimateItemForm";
 import { useItemEditor } from "../../../context/ItemEditorContext";
 import { Card } from "../../../components/ui";
 import { Theme } from "../../../theme";
@@ -72,7 +75,7 @@ export default function EstimateItemEditorScreen() {
   }, [config, router]);
 
   const handleSubmit = useCallback(
-    async (payload: Parameters<NonNullable<typeof config>["onSubmit"]>[0]) => {
+    async (payload: EstimateItemFormSubmit): Promise<void> => {
       if (!config) {
         return;
       }
@@ -86,7 +89,7 @@ export default function EstimateItemEditorScreen() {
     [closeEditor, config, router],
   );
 
-  const handleCancel = useCallback(() => {
+  const handleCancel = useCallback((): void => {
     if (!config) {
       return;
     }
@@ -98,6 +101,18 @@ export default function EstimateItemEditorScreen() {
     }
   }, [closeEditor, config, router]);
 
+  const templates = useMemo<EstimateItemTemplate[]>(() => {
+    if (!config?.templates) {
+      return [];
+    }
+
+    if (typeof config.templates === "function") {
+      return config.templates() ?? [];
+    }
+
+    return config.templates ?? [];
+  }, [config]);
+
   if (!config) {
     return (
       <View style={styles.loadingContainer}>
@@ -105,8 +120,6 @@ export default function EstimateItemEditorScreen() {
       </View>
     );
   }
-
-  const templates = typeof config.templates === "function" ? config.templates() : config.templates;
 
   return (
     <ScrollView style={styles.screen} contentContainerStyle={styles.content}>

--- a/app/(tabs)/estimates/new.tsx
+++ b/app/(tabs)/estimates/new.tsx
@@ -21,6 +21,7 @@ import { type EstimateItemFormSubmit, type EstimateItemTemplate } from "../../..
 import { Button, Card, Input, ListItem } from "../../../components/ui";
 import { useAuth } from "../../../context/AuthContext";
 import { useItemEditor, type ItemEditorConfig } from "../../../context/ItemEditorContext";
+import type { EstimateItemRecord } from "../../../types/estimates";
 import { useSettings } from "../../../context/SettingsContext";
 import { sanitizeEstimateForQueue } from "../../../lib/estimates";
 import {
@@ -96,20 +97,7 @@ type PersistedEstimateRecord = {
   job_details: string | null;
 };
 
-type PersistedEstimateItem = {
-  id: string;
-  estimate_id: string;
-  description: string;
-  quantity: number;
-  unit_price: number;
-  base_total: number;
-  total: number;
-  apply_markup: number | null;
-  catalog_item_id: string | null;
-  version: number;
-  updated_at: string;
-  deleted_at: string | null;
-};
+type PersistedEstimateItem = EstimateItemRecord;
 
 type SavedEstimateContext = {
   estimate: PersistedEstimateRecord;

--- a/context/ItemEditorContext.tsx
+++ b/context/ItemEditorContext.tsx
@@ -10,15 +10,13 @@ import type {
   EstimateItemFormSubmit,
   EstimateItemTemplate,
 } from "../components/EstimateItemForm";
+import type { EstimateItemRecord } from "../types/estimates";
 import type { MarkupMode } from "../lib/estimateMath";
 
 export type ItemEditorConfig = {
   title: string;
   submitLabel?: string;
-  initialValue?: {
-    description: string;
-    quantity: number;
-    unit_price: number;
+  initialValue?: Pick<EstimateItemRecord, "description" | "quantity" | "unit_price"> & {
     apply_markup?: boolean;
   };
   initialTemplateId?: string | null;

--- a/types/estimates.ts
+++ b/types/estimates.ts
@@ -1,0 +1,15 @@
+export type EstimateItemRecord = {
+  id: string;
+  estimate_id: string;
+  description: string;
+  quantity: number;
+  unit_price: number;
+  base_total: number;
+  total: number;
+  apply_markup: number | null;
+  catalog_item_id: string | null;
+  version: number;
+  updated_at: string;
+  deleted_at: string | null;
+};
+


### PR DESCRIPTION
## Summary
- add a shared `EstimateItemRecord` model and reuse it across estimate flows
- tighten the item editor context typing and callbacks for the editor screen
- ensure the item editor resolves templates with explicit types and return values

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68dfed79085c832380f521d6c9f290c0