### PR TITLE
Fix type safety across UI components

### DIFF
--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -16,6 +16,8 @@ export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
 
 type ButtonAlignment = "inline" | "full";
 
+type ButtonLabelVariant = `${ButtonVariant}Label`;
+
 export interface ButtonProps {
   label: string;
   onPress?: () => void;
@@ -56,6 +58,8 @@ export function Button({
     onPress();
   }, [isDisabled, onPress]);
 
+  const labelVariant: ButtonLabelVariant = `${variant}Label`;
+
   return (
     <Pressable
       accessibilityLabel={accessibilityLabel ?? label}
@@ -83,7 +87,7 @@ export function Button({
         ) : (
           <>
             {leadingIcon ? <View style={styles.icon}>{leadingIcon}</View> : null}
-            <Text style={[styles.label, styles[`${variant}Label`], textStyle]}>{label}</Text>
+            <Text style={[styles.label, styles[labelVariant], textStyle]}>{label}</Text>
             {trailingIcon ? <View style={styles.icon}>{trailingIcon}</View> : null}
           </>
         )}

--- a/components/ui/FAB.tsx
+++ b/components/ui/FAB.tsx
@@ -5,6 +5,8 @@ import { useThemeContext } from "../../theme/ThemeProvider";
 
 type FABPalette = "auto" | "primary" | "highlight";
 
+type ResolvedFABPalette = Exclude<FABPalette, "auto">;
+
 export interface FABProps {
   icon: ReactNode;
   onPress?: () => void;
@@ -16,7 +18,7 @@ export interface FABProps {
 export function FAB({ icon, onPress, accessibilityLabel, palette = "auto", style }: FABProps) {
   const { theme, isDark } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
-  const resolvedPalette =
+  const resolvedPalette: ResolvedFABPalette =
     palette === "auto" ? (isDark ? "highlight" : "primary") : palette;
 
   return (

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -1,5 +1,7 @@
 import { ForwardedRef, ReactNode, forwardRef, useCallback, useMemo, useState } from "react";
 import {
+  BlurEvent,
+  FocusEvent,
   Platform,
   StyleProp,
   StyleSheet,
@@ -33,6 +35,8 @@ export const Input = forwardRef<TextInput, InputProps>(function Input(
     containerStyle,
     inputStyle,
     multiline,
+    onFocus,
+    onBlur,
     ...textInputProps
   }: InputProps,
   ref: ForwardedRef<TextInput>,
@@ -42,19 +46,19 @@ export const Input = forwardRef<TextInput, InputProps>(function Input(
   const [isFocused, setFocused] = useState(false);
 
   const handleFocus = useCallback(
-    (event: any) => {
+    (event: FocusEvent) => {
       setFocused(true);
-      textInputProps.onFocus?.(event);
+      onFocus?.(event);
     },
-    [textInputProps],
+    [onFocus],
   );
 
   const handleBlur = useCallback(
-    (event: any) => {
+    (event: BlurEvent) => {
       setFocused(false);
-      textInputProps.onBlur?.(event);
+      onBlur?.(event);
     },
-    [textInputProps],
+    [onBlur],
   );
 
   const fieldState = useMemo(() => {

--- a/components/ui/ListItem.tsx
+++ b/components/ui/ListItem.tsx
@@ -14,6 +14,8 @@ export interface ListItemProps {
   titleStyle?: StyleProp<TextStyle>;
   subtitleStyle?: StyleProp<TextStyle>;
   amountStyle?: StyleProp<TextStyle>;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
 }
 
 export function ListItem({
@@ -27,6 +29,8 @@ export function ListItem({
   titleStyle,
   subtitleStyle,
   amountStyle,
+  accessibilityHint,
+  accessibilityLabel,
 }: ListItemProps) {
   const { theme } = useThemeContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
@@ -42,6 +46,8 @@ export function ListItem({
     return (
       <Pressable
         accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel ?? title}
+        accessibilityHint={accessibilityHint}
         onPress={onPress}
         style={({ pressed }) => [styles.container, pressed ? styles.pressed : null, style]}
       >


### PR DESCRIPTION
## Summary
- ensure button label styles are selected with a strongly typed key
- tighten input focus and blur handlers to use native event types
- add explicit types for FAB palette resolution and list item accessibility props

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68dff08e7ff48323a8ba30ce48fa1d17