### PR TITLE
Fix context provider typings

### DIFF
--- a/context/ItemEditorContext.tsx
+++ b/context/ItemEditorContext.tsx
@@ -1,10 +1,10 @@
 import React, {
+  type ReactNode,
   createContext,
   useCallback,
   useContext,
   useMemo,
   useState,
-  type PropsWithChildren,
 } from "react";
 import type {
   EstimateItemFormSubmit,
@@ -36,7 +36,11 @@ export type ItemEditorContextValue = {
 
 const ItemEditorContext = createContext<ItemEditorContextValue | undefined>(undefined);
 
-export function ItemEditorProvider({ children }: PropsWithChildren) {
+type ItemEditorProviderProps = {
+  children: ReactNode;
+};
+
+export function ItemEditorProvider({ children }: ItemEditorProviderProps) {
   const [config, setConfig] = useState<ItemEditorConfig | null>(null);
 
   const openEditor = useCallback((nextConfig: ItemEditorConfig) => {

--- a/context/SettingsContext.tsx
+++ b/context/SettingsContext.tsx
@@ -108,7 +108,11 @@ const STORAGE_KEY = "@quickquote/settings";
 
 const SettingsContext = createContext<SettingsContextValue | undefined>(undefined);
 
-export function SettingsProvider({ children }: { children: ReactNode }) {
+type SettingsProviderProps = {
+  children: ReactNode;
+};
+
+export function SettingsProvider({ children }: SettingsProviderProps) {
   const [settings, setSettings] = useState<SettingsState>(() => ({
     ...DEFAULT_SETTINGS,
     companyProfile: { ...DEFAULT_COMPANY_PROFILE },
@@ -404,7 +408,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
 }
 
-export function useSettings() {
+export function useSettings(): SettingsContextValue {
   const context = useContext(SettingsContext);
 
   if (!context) {


### PR DESCRIPTION
## Summary
- type provider children props explicitly across contexts
- enforce typed return values for useSettings hook
- adjust item editor context imports to avoid PropsWithChildren

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68dff1df9b648323863c6bec87e35d0c