### PR TITLE
Clean up type safety on estimate and settings screens

### DIFF
--- a/app/(tabs)/estimates/new.tsx
+++ b/app/(tabs)/estimates/new.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "expo-router";
 import {
@@ -38,7 +37,7 @@ import {
   persistLocalPhotoCopy,
 } from "../../../lib/storage";
 import { listSavedItems, upsertSavedItem, type SavedItemRecord } from "../../../lib/savedItems";
-import { Theme } from "../../../theme";
+import type { Theme } from "../../../theme";
 import { useThemeContext } from "../../../theme/ThemeProvider";
 import type { CustomerRecord } from "../../../types/customers";
 
@@ -199,7 +198,7 @@ function createStyles(theme: Theme) {
     content: {
       paddingHorizontal: theme.spacing.xl,
       paddingTop: theme.spacing.xl,
-      paddingBottom: theme.spacing.xxxl,
+      paddingBottom: theme.spacing.xxl,
       gap: theme.spacing.xl,
     },
     sectionHeader: {
@@ -978,25 +977,6 @@ export default function NewEstimateScreen() {
     );
   }, []);
 
-  const handleSaveAndContinue = useCallback(async () => {
-    if (saving) {
-      return;
-    }
-
-    try {
-      setSaving(true);
-      const context = await saveEstimate();
-      if (!context) {
-        return;
-      }
-      if (typeof navigation.replace === "function") {
-        navigation.replace(`/(tabs)/estimates/${context.estimate.id}`);
-      }
-    } finally {
-      setSaving(false);
-    }
-  }, [navigation, saveEstimate, saving]);
-
   const handleCancel = useCallback(() => {
     Alert.alert("Discard estimate?", "Your current changes will be lost.", [
       { text: "Keep editing", style: "cancel" },
@@ -1345,6 +1325,25 @@ export default function NewEstimateScreen() {
     taxRateValue,
     userId,
   ]);
+
+  const handleSaveAndContinue = useCallback(async () => {
+    if (saving) {
+      return;
+    }
+
+    try {
+      setSaving(true);
+      const context = await saveEstimate();
+      if (!context) {
+        return;
+      }
+      if (typeof navigation.replace === "function") {
+        navigation.replace(`/(tabs)/estimates/${context.estimate.id}`);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }, [navigation, saveEstimate, saving]);
 
   return (
     <SafeAreaView style={styles.safeArea}>

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
@@ -17,8 +16,9 @@ import { Badge, Button, Card, Input, ListItem } from "../../components/ui";
 import LogoPicker from "../../components/LogoPicker";
 import { useAuth } from "../../context/AuthContext";
 import { useSettings } from "../../context/SettingsContext";
+import type { HapticIntensity } from "../../context/SettingsContext";
 import type { MarkupMode } from "../../lib/estimateMath";
-import { Theme } from "../../theme";
+import type { Theme } from "../../theme";
 import { useThemeContext } from "../../theme/ThemeProvider";
 
 const HAPTIC_LABELS = ["Subtle", "Balanced", "Bold"];
@@ -118,6 +118,21 @@ export default function Settings() {
       setHourlyRate(Math.max(0, Math.round(parsed * 100) / 100));
     },
     [setHourlyRate],
+  );
+
+  const handleUpdateTaxRate = useCallback(
+    (value: string) => {
+      const normalized = value.replace(/[^0-9.]/g, "");
+      const parsed = Number.parseFloat(normalized);
+      if (Number.isNaN(parsed)) {
+        setTaxRate(0);
+        return;
+      }
+
+      const clamped = Math.max(0, Math.min(parsed, 100));
+      setTaxRate(clamped);
+    },
+    [setTaxRate],
   );
 
   const handleSavePreferences = useCallback(() => {
@@ -254,7 +269,8 @@ export default function Settings() {
                 step={1}
                 value={settings.hapticIntensity}
                 onSlidingComplete={(value) => {
-                  setHapticIntensity(value);
+                  const intensity = Math.round(value) as HapticIntensity;
+                  setHapticIntensity(intensity);
                   triggerHaptic();
                 }}
                 minimumTrackTintColor={theme.colors.accent}
@@ -319,7 +335,7 @@ export default function Settings() {
             label="Sales tax percentage"
             value={taxRateInput}
             onChangeText={setTaxRateInput}
-            onBlur={() => handleUpdatePercentage(taxRateInput, setTaxRate)}
+            onBlur={() => handleUpdateTaxRate(taxRateInput)}
             keyboardType="decimal-pad"
             rightElement={<Text style={styles.inputAdornment}>%</Text>}
           />


### PR DESCRIPTION
## Summary
- remove `@ts-nocheck` directives from the estimate creation and settings tabs by addressing the underlying typing issues
- switch to type-only imports, fix spacing references, and ensure callbacks are declared before use for the estimate flow
- tighten settings helpers for tax rate and haptic intensity updates so all handlers operate with explicit types

## Testing
- npx tsc --noEmit
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dff280848883238655293dbf3a8b0e