### PR TITLE
Fix keyboard handling on auth screens

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -24,6 +24,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     },
     edgeToEdgeEnabled: true,
     predictiveBackGestureEnabled: false,
+    windowSoftInputMode: "adjustResize",
   },
   web: {
     favicon: "./assets/favicon.png",

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,6 +1,14 @@
 import { Link, router } from "expo-router";
 import { useMemo, useState } from "react";
-import { Alert, KeyboardAvoidingView, Platform, StyleSheet, View } from "react-native";
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
 import { Body, Button, Card, Input, Subtitle, Title } from "../../components/ui";
@@ -42,62 +50,79 @@ export default function LoginScreen() {
 
   return (
     <KeyboardAvoidingView
-      behavior={Platform.select({ ios: "padding", android: undefined })}
-      style={styles.container}
+      behavior={Platform.select({ ios: "padding", android: "height" })}
+      style={styles.keyboardAvoider}
     >
-      <Card style={styles.card}>
-        <View style={styles.logoContainer}>
-          <BrandLogo size={80} />
-        </View>
-        <Title style={styles.title}>Welcome back</Title>
-        <Subtitle style={styles.subtitle}>
-          Sign in to manage estimates, customers, and your team from anywhere.
-        </Subtitle>
-        <Input
-          autoCapitalize="none"
-          autoComplete="email"
-          autoCorrect={false}
-          keyboardType="email-address"
-          placeholder="you@example.com"
-          label="Email"
-          value={email}
-          onChangeText={setEmail}
-        />
-        <Input
-          autoCapitalize="none"
-          autoComplete="password"
-          placeholder="••••••••"
-          secureTextEntry
-          label="Password"
-          value={password}
-          onChangeText={setPassword}
-        />
-        <Button
-          label="Sign in"
-          onPress={handleLogin}
-          loading={loading}
-          accessibilityLabel="Sign in to QuickQuote"
-        />
-        <View style={styles.linksRow}>
-          <Link href="/(auth)/forgot-password">
-            <Body style={styles.link}>Forgot password?</Body>
-          </Link>
-          <Link href="/(auth)/signup">
-            <Body style={styles.link}>Create account</Body>
-          </Link>
-        </View>
-      </Card>
+      <SafeAreaView style={styles.safeArea}>
+        <ScrollView
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+        >
+          <Card style={styles.card}>
+            <View style={styles.logoContainer}>
+              <BrandLogo size={80} />
+            </View>
+            <Title style={styles.title}>Welcome back</Title>
+            <Subtitle style={styles.subtitle}>
+              Sign in to manage estimates, customers, and your team from anywhere.
+            </Subtitle>
+            <Input
+              autoCapitalize="none"
+              autoComplete="email"
+              autoCorrect={false}
+              keyboardType="email-address"
+              placeholder="you@example.com"
+              label="Email"
+              value={email}
+              onChangeText={setEmail}
+            />
+            <Input
+              autoCapitalize="none"
+              autoComplete="password"
+              placeholder="••••••••"
+              secureTextEntry
+              label="Password"
+              value={password}
+              onChangeText={setPassword}
+            />
+            <Button
+              label="Sign in"
+              onPress={handleLogin}
+              loading={loading}
+              accessibilityLabel="Sign in to QuickQuote"
+            />
+            <View style={styles.linksRow}>
+              <Link href="/(auth)/forgot-password">
+                <Body style={styles.link}>Forgot password?</Body>
+              </Link>
+              <Link href="/(auth)/signup">
+                <Body style={styles.link}>Create account</Body>
+              </Link>
+            </View>
+          </Card>
+        </ScrollView>
+      </SafeAreaView>
     </KeyboardAvoidingView>
   );
 }
 
 function createStyles(theme: Theme) {
   return StyleSheet.create({
-    container: {
+    keyboardAvoider: {
       flex: 1,
       backgroundColor: theme.colors.background,
+    },
+    safeArea: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    scrollContent: {
+      flexGrow: 1,
       justifyContent: "center",
       paddingHorizontal: theme.spacing.xl,
+      paddingVertical: theme.spacing.xl,
+      backgroundColor: theme.colors.background,
     },
     card: {
       gap: theme.spacing.lg,

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -1,6 +1,14 @@
 import { Link, router } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
-import { Alert, KeyboardAvoidingView, Platform, ScrollView, StyleSheet, View } from "react-native";
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
 import LogoPicker from "../../components/LogoPicker";
@@ -79,93 +87,98 @@ export default function SignupScreen() {
 
   return (
     <KeyboardAvoidingView
-      behavior={Platform.select({ ios: "padding", android: undefined })}
-      style={styles.container}
+      behavior={Platform.select({ ios: "padding", android: "height" })}
+      style={styles.keyboardAvoider}
     >
-      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
-        <Card style={styles.card}>
-          <View style={styles.logoContainer}>
-            <BrandLogo size={80} />
-          </View>
-          <Title style={styles.title}>Create your account</Title>
-          <View style={styles.section}>
-            <Subtitle style={styles.sectionTitle}>Account details</Subtitle>
-            <Body style={styles.sectionSubtitle}>
-              Sign in with your work email so we can keep your estimates in sync.
-            </Body>
-            <Input
-              autoCapitalize="none"
-              autoComplete="email"
-              autoCorrect={false}
-              keyboardType="email-address"
-              placeholder="you@example.com"
-              label="Email"
-              value={email}
-              onChangeText={setEmail}
-            />
-            <Input
-              autoCapitalize="none"
-              autoComplete="password"
-              placeholder="Create a password"
-              secureTextEntry
-              label="Password"
-              value={password}
-              onChangeText={setPassword}
-            />
-            <Input
-              autoCapitalize="none"
-              autoComplete="password"
-              placeholder="Confirm your password"
-              secureTextEntry
-              label="Confirm password"
-              value={confirmPassword}
-              onChangeText={setConfirmPassword}
-            />
-          </View>
+      <SafeAreaView style={styles.safeArea}>
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <Card style={styles.card}>
+            <View style={styles.logoContainer}>
+              <BrandLogo size={80} />
+            </View>
+            <Title style={styles.title}>Create your account</Title>
+            <View style={styles.section}>
+              <Subtitle style={styles.sectionTitle}>Account details</Subtitle>
+              <Body style={styles.sectionSubtitle}>
+                Sign in with your work email so we can keep your estimates in sync.
+              </Body>
+              <Input
+                autoCapitalize="none"
+                autoComplete="email"
+                autoCorrect={false}
+                keyboardType="email-address"
+                placeholder="you@example.com"
+                label="Email"
+                value={email}
+                onChangeText={setEmail}
+              />
+              <Input
+                autoCapitalize="none"
+                autoComplete="password"
+                placeholder="Create a password"
+                secureTextEntry
+                label="Password"
+                value={password}
+                onChangeText={setPassword}
+              />
+              <Input
+                autoCapitalize="none"
+                autoComplete="password"
+                placeholder="Confirm your password"
+                secureTextEntry
+                label="Confirm password"
+                value={confirmPassword}
+                onChangeText={setConfirmPassword}
+              />
+            </View>
 
-          <View style={styles.section}>
-            <Subtitle style={styles.sectionTitle}>Company profile</Subtitle>
-            <Body style={styles.sectionSubtitle}>
-              We’ll preload every estimate with this information. You can tweak it anytime in
-              Settings.
-            </Body>
-            <LogoPicker value={logoUri} onChange={setLogoUri} />
-            <Input
-              placeholder="Acme Landscaping"
-              label="Company name"
-              value={companyName}
-              onChangeText={setCompanyName}
-            />
-            <Input
-              placeholder="hello@acme.com"
-              keyboardType="email-address"
-              autoCapitalize="none"
-              label="Company email"
-              value={companyEmail}
-              onChangeText={setCompanyEmail}
-            />
-            <Input
-              placeholder="(555) 555-0199"
-              keyboardType="phone-pad"
-              label="Phone"
-              value={companyPhone}
-              onChangeText={setCompanyPhone}
-            />
-            <Input
-              placeholder="https://acme.com"
-              autoCapitalize="none"
-              label="Website"
-              value={companyWebsite}
-              onChangeText={setCompanyWebsite}
-            />
-            <Input
-              placeholder="123 Main St, Springfield"
-              label="Business address"
-              value={companyAddress}
-              onChangeText={setCompanyAddress}
-              multiline
-            />
-          </View>
+            <View style={styles.section}>
+              <Subtitle style={styles.sectionTitle}>Company profile</Subtitle>
+              <Body style={styles.sectionSubtitle}>
+                We’ll preload every estimate with this information. You can tweak it anytime in
+                Settings.
+              </Body>
+              <LogoPicker value={logoUri} onChange={setLogoUri} />
+              <Input
+                placeholder="Acme Landscaping"
+                label="Company name"
+                value={companyName}
+                onChangeText={setCompanyName}
+              />
+              <Input
+                placeholder="hello@acme.com"
+                keyboardType="email-address"
+                autoCapitalize="none"
+                label="Company email"
+                value={companyEmail}
+                onChangeText={setCompanyEmail}
+              />
+              <Input
+                placeholder="(555) 555-0199"
+                keyboardType="phone-pad"
+                label="Phone"
+                value={companyPhone}
+                onChangeText={setCompanyPhone}
+              />
+              <Input
+                placeholder="https://acme.com"
+                autoCapitalize="none"
+                label="Website"
+                value={companyWebsite}
+                onChangeText={setCompanyWebsite}
+              />
+              <Input
+                placeholder="123 Main St, Springfield"
+                label="Business address"
+                value={companyAddress}
+                onChangeText={setCompanyAddress}
+                multiline
+              />
+            </View>
 
           <Button label="Sign up" onPress={handleSignup} loading={loading} />
           <View style={styles.linksRow}>
@@ -175,22 +188,27 @@ export default function SignupScreen() {
           </View>
         </Card>
       </ScrollView>
-    </KeyboardAvoidingView>
+    </SafeAreaView>
+  </KeyboardAvoidingView>
   );
 }
 
 function createStyles(theme: Theme) {
   return StyleSheet.create({
-    container: {
+    keyboardAvoider: {
       flex: 1,
       backgroundColor: theme.colors.background,
-      justifyContent: "center",
-      paddingHorizontal: theme.spacing.xl,
+    },
+    safeArea: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
     },
     card: {
       gap: theme.spacing.xl,
     },
     scrollContent: {
+      flexGrow: 1,
+      paddingHorizontal: theme.spacing.xl,
       paddingVertical: theme.spacing.xl,
     },
     logoContainer: {


### PR DESCRIPTION
## Summary
- wrap the login screen in a keyboard aware SafeAreaView and scroll container to prevent the keyboard from covering inputs
- apply the same keyboard avoidance structure to the signup flow and ensure scroll interactions persist while typing
- configure Android to use adjustResize so the root view resizes instead of causing flicker when the keyboard opens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dff7e295f4832393d6d298547a7306