### PR TITLE
Fix keyboard handling for auth screens

### DIFF
--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,5 +1,11 @@
 import { Redirect, Stack } from "expo-router";
-import { ActivityIndicator, StyleSheet, View } from "react-native";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  StyleSheet,
+  View,
+} from "react-native";
 import { useAuth } from "../../context/AuthContext";
 
 export default function AuthLayout() {
@@ -17,10 +23,26 @@ export default function AuthLayout() {
     return <Redirect href="/(tabs)/home" />;
   }
 
-  return <Stack screenOptions={{ headerShown: false }} />;
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.select({ ios: "padding", android: "height" })}
+      style={styles.keyboardAvoider}
+    >
+      <Stack
+        screenOptions={{
+          headerShown: false,
+          presentation: "card",
+          keyboardHandlingEnabled: true,
+        }}
+      />
+    </KeyboardAvoidingView>
+  );
 }
 
 const styles = StyleSheet.create({
+  keyboardAvoider: {
+    flex: 1,
+  },
   loadingContainer: {
     alignItems: "center",
     flex: 1,

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,13 +1,6 @@
 import { Link, router } from "expo-router";
 import { useMemo, useState } from "react";
-import {
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  StyleSheet,
-  View,
-} from "react-native";
+import { Alert, ScrollView, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
@@ -49,70 +42,61 @@ export default function LoginScreen() {
   };
 
   return (
-    <KeyboardAvoidingView
-      behavior={Platform.select({ ios: "padding", android: "height" })}
-      style={styles.keyboardAvoider}
-    >
-      <SafeAreaView style={styles.safeArea}>
-        <ScrollView
-          keyboardShouldPersistTaps="handled"
-          contentContainerStyle={styles.scrollContent}
-          showsVerticalScrollIndicator={false}
-        >
-          <Card style={styles.card}>
-            <View style={styles.logoContainer}>
-              <BrandLogo size={80} />
-            </View>
-            <Title style={styles.title}>Welcome back</Title>
-            <Subtitle style={styles.subtitle}>
-              Sign in to manage estimates, customers, and your team from anywhere.
-            </Subtitle>
-            <Input
-              autoCapitalize="none"
-              autoComplete="email"
-              autoCorrect={false}
-              keyboardType="email-address"
-              placeholder="you@example.com"
-              label="Email"
-              value={email}
-              onChangeText={setEmail}
-            />
-            <Input
-              autoCapitalize="none"
-              autoComplete="password"
-              placeholder="••••••••"
-              secureTextEntry
-              label="Password"
-              value={password}
-              onChangeText={setPassword}
-            />
-            <Button
-              label="Sign in"
-              onPress={handleLogin}
-              loading={loading}
-              accessibilityLabel="Sign in to QuickQuote"
-            />
-            <View style={styles.linksRow}>
-              <Link href="/(auth)/forgot-password">
-                <Body style={styles.link}>Forgot password?</Body>
-              </Link>
-              <Link href="/(auth)/signup">
-                <Body style={styles.link}>Create account</Body>
-              </Link>
-            </View>
-          </Card>
-        </ScrollView>
-      </SafeAreaView>
-    </KeyboardAvoidingView>
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView
+        keyboardShouldPersistTaps="handled"
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <Card style={styles.card}>
+          <View style={styles.logoContainer}>
+            <BrandLogo size={80} />
+          </View>
+          <Title style={styles.title}>Welcome back</Title>
+          <Subtitle style={styles.subtitle}>
+            Sign in to manage estimates, customers, and your team from anywhere.
+          </Subtitle>
+          <Input
+            autoCapitalize="none"
+            autoComplete="email"
+            autoCorrect={false}
+            keyboardType="email-address"
+            placeholder="you@example.com"
+            label="Email"
+            value={email}
+            onChangeText={setEmail}
+          />
+          <Input
+            autoCapitalize="none"
+            autoComplete="password"
+            placeholder="••••••••"
+            secureTextEntry
+            label="Password"
+            value={password}
+            onChangeText={setPassword}
+          />
+          <Button
+            label="Sign in"
+            onPress={handleLogin}
+            loading={loading}
+            accessibilityLabel="Sign in to QuickQuote"
+          />
+          <View style={styles.linksRow}>
+            <Link href="/(auth)/forgot-password">
+              <Body style={styles.link}>Forgot password?</Body>
+            </Link>
+            <Link href="/(auth)/signup">
+              <Body style={styles.link}>Create account</Body>
+            </Link>
+          </View>
+        </Card>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 function createStyles(theme: Theme) {
   return StyleSheet.create({
-    keyboardAvoider: {
-      flex: 1,
-      backgroundColor: theme.colors.background,
-    },
     safeArea: {
       flex: 1,
       backgroundColor: theme.colors.background,

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -1,13 +1,6 @@
 import { Link, router } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
-import {
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  StyleSheet,
-  View,
-} from "react-native";
+import { Alert, ScrollView, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
@@ -86,99 +79,95 @@ export default function SignupScreen() {
   };
 
   return (
-    <KeyboardAvoidingView
-      behavior={Platform.select({ ios: "padding", android: "height" })}
-      style={styles.keyboardAvoider}
-    >
-      <SafeAreaView style={styles.safeArea}>
-        <ScrollView
-          contentContainerStyle={styles.scrollContent}
-          keyboardShouldPersistTaps="handled"
-          showsVerticalScrollIndicator={false}
-        >
-          <Card style={styles.card}>
-            <View style={styles.logoContainer}>
-              <BrandLogo size={80} />
-            </View>
-            <Title style={styles.title}>Create your account</Title>
-            <View style={styles.section}>
-              <Subtitle style={styles.sectionTitle}>Account details</Subtitle>
-              <Body style={styles.sectionSubtitle}>
-                Sign in with your work email so we can keep your estimates in sync.
-              </Body>
-              <Input
-                autoCapitalize="none"
-                autoComplete="email"
-                autoCorrect={false}
-                keyboardType="email-address"
-                placeholder="you@example.com"
-                label="Email"
-                value={email}
-                onChangeText={setEmail}
-              />
-              <Input
-                autoCapitalize="none"
-                autoComplete="password"
-                placeholder="Create a password"
-                secureTextEntry
-                label="Password"
-                value={password}
-                onChangeText={setPassword}
-              />
-              <Input
-                autoCapitalize="none"
-                autoComplete="password"
-                placeholder="Confirm your password"
-                secureTextEntry
-                label="Confirm password"
-                value={confirmPassword}
-                onChangeText={setConfirmPassword}
-              />
-            </View>
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <Card style={styles.card}>
+          <View style={styles.logoContainer}>
+            <BrandLogo size={80} />
+          </View>
+          <Title style={styles.title}>Create your account</Title>
+          <View style={styles.section}>
+            <Subtitle style={styles.sectionTitle}>Account details</Subtitle>
+            <Body style={styles.sectionSubtitle}>
+              Sign in with your work email so we can keep your estimates in sync.
+            </Body>
+            <Input
+              autoCapitalize="none"
+              autoComplete="email"
+              autoCorrect={false}
+              keyboardType="email-address"
+              placeholder="you@example.com"
+              label="Email"
+              value={email}
+              onChangeText={setEmail}
+            />
+            <Input
+              autoCapitalize="none"
+              autoComplete="password"
+              placeholder="Create a password"
+              secureTextEntry
+              label="Password"
+              value={password}
+              onChangeText={setPassword}
+            />
+            <Input
+              autoCapitalize="none"
+              autoComplete="password"
+              placeholder="Confirm your password"
+              secureTextEntry
+              label="Confirm password"
+              value={confirmPassword}
+              onChangeText={setConfirmPassword}
+            />
+          </View>
 
-            <View style={styles.section}>
-              <Subtitle style={styles.sectionTitle}>Company profile</Subtitle>
-              <Body style={styles.sectionSubtitle}>
-                We’ll preload every estimate with this information. You can tweak it anytime in
-                Settings.
-              </Body>
-              <LogoPicker value={logoUri} onChange={setLogoUri} />
-              <Input
-                placeholder="Acme Landscaping"
-                label="Company name"
-                value={companyName}
-                onChangeText={setCompanyName}
-              />
-              <Input
-                placeholder="hello@acme.com"
-                keyboardType="email-address"
-                autoCapitalize="none"
-                label="Company email"
-                value={companyEmail}
-                onChangeText={setCompanyEmail}
-              />
-              <Input
-                placeholder="(555) 555-0199"
-                keyboardType="phone-pad"
-                label="Phone"
-                value={companyPhone}
-                onChangeText={setCompanyPhone}
-              />
-              <Input
-                placeholder="https://acme.com"
-                autoCapitalize="none"
-                label="Website"
-                value={companyWebsite}
-                onChangeText={setCompanyWebsite}
-              />
-              <Input
-                placeholder="123 Main St, Springfield"
-                label="Business address"
-                value={companyAddress}
-                onChangeText={setCompanyAddress}
-                multiline
-              />
-            </View>
+          <View style={styles.section}>
+            <Subtitle style={styles.sectionTitle}>Company profile</Subtitle>
+            <Body style={styles.sectionSubtitle}>
+              We’ll preload every estimate with this information. You can tweak it anytime in
+              Settings.
+            </Body>
+            <LogoPicker value={logoUri} onChange={setLogoUri} />
+            <Input
+              placeholder="Acme Landscaping"
+              label="Company name"
+              value={companyName}
+              onChangeText={setCompanyName}
+            />
+            <Input
+              placeholder="hello@acme.com"
+              keyboardType="email-address"
+              autoCapitalize="none"
+              label="Company email"
+              value={companyEmail}
+              onChangeText={setCompanyEmail}
+            />
+            <Input
+              placeholder="(555) 555-0199"
+              keyboardType="phone-pad"
+              label="Phone"
+              value={companyPhone}
+              onChangeText={setCompanyPhone}
+            />
+            <Input
+              placeholder="https://acme.com"
+              autoCapitalize="none"
+              label="Website"
+              value={companyWebsite}
+              onChangeText={setCompanyWebsite}
+            />
+            <Input
+              placeholder="123 Main St, Springfield"
+              label="Business address"
+              value={companyAddress}
+              onChangeText={setCompanyAddress}
+              multiline
+            />
+          </View>
 
           <Button label="Sign up" onPress={handleSignup} loading={loading} />
           <View style={styles.linksRow}>
@@ -189,16 +178,11 @@ export default function SignupScreen() {
         </Card>
       </ScrollView>
     </SafeAreaView>
-  </KeyboardAvoidingView>
   );
 }
 
 function createStyles(theme: Theme) {
   return StyleSheet.create({
-    keyboardAvoider: {
-      flex: 1,
-      backgroundColor: theme.colors.background,
-    },
     safeArea: {
       flex: 1,
       backgroundColor: theme.colors.background,


### PR DESCRIPTION
## Summary
- move the shared auth stack inside a KeyboardAvoidingView and enable keyboard-friendly screen options
- simplify login and signup screens to rely on the shared wrapper while keeping scroll behavior stable

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dff937fd048323b862fbea33da5e1e