### PR TITLE
Refactor auth screens keyboard layout

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,6 +1,13 @@
 import { Link, router } from "expo-router";
 import { useMemo, useState } from "react";
-import { Alert, ScrollView, StyleSheet, View } from "react-native";
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  View,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
@@ -42,61 +49,71 @@ export default function LoginScreen() {
   };
 
   return (
-    <SafeAreaView style={styles.safeArea}>
-      <ScrollView
-        keyboardShouldPersistTaps="handled"
-        contentContainerStyle={styles.scrollContent}
-        showsVerticalScrollIndicator={false}
-      >
-        <Card style={styles.card}>
-          <View style={styles.logoContainer}>
-            <BrandLogo size={80} />
-          </View>
-          <Title style={styles.title}>Welcome back</Title>
-          <Subtitle style={styles.subtitle}>
-            Sign in to manage estimates, customers, and your team from anywhere.
-          </Subtitle>
-          <Input
-            autoCapitalize="none"
-            autoComplete="email"
-            autoCorrect={false}
-            keyboardType="email-address"
-            placeholder="you@example.com"
-            label="Email"
-            value={email}
-            onChangeText={setEmail}
-          />
-          <Input
-            autoCapitalize="none"
-            autoComplete="password"
-            placeholder="••••••••"
-            secureTextEntry
-            label="Password"
-            value={password}
-            onChangeText={setPassword}
-          />
-          <Button
-            label="Sign in"
-            onPress={handleLogin}
-            loading={loading}
-            accessibilityLabel="Sign in to QuickQuote"
-          />
-          <View style={styles.linksRow}>
-            <Link href="/(auth)/forgot-password">
-              <Body style={styles.link}>Forgot password?</Body>
-            </Link>
-            <Link href="/(auth)/signup">
-              <Body style={styles.link}>Create account</Body>
-            </Link>
-          </View>
-        </Card>
-      </ScrollView>
-    </SafeAreaView>
+    <KeyboardAvoidingView
+      style={styles.keyboardAvoider}
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+      keyboardVerticalOffset={Platform.OS === "ios" ? 80 : 0}
+    >
+      <SafeAreaView style={styles.safeArea}>
+        <ScrollView
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+        >
+          <Card style={styles.card}>
+            <View style={styles.logoContainer}>
+              <BrandLogo size={80} />
+            </View>
+            <Title style={styles.title}>Welcome back</Title>
+            <Subtitle style={styles.subtitle}>
+              Sign in to manage estimates, customers, and your team from anywhere.
+            </Subtitle>
+            <Input
+              autoCapitalize="none"
+              autoComplete="email"
+              autoCorrect={false}
+              keyboardType="email-address"
+              placeholder="you@example.com"
+              label="Email"
+              value={email}
+              onChangeText={setEmail}
+            />
+            <Input
+              autoCapitalize="none"
+              autoComplete="password"
+              placeholder="••••••••"
+              secureTextEntry
+              label="Password"
+              value={password}
+              onChangeText={setPassword}
+            />
+            <Button
+              label="Sign in"
+              onPress={handleLogin}
+              loading={loading}
+              accessibilityLabel="Sign in to QuickQuote"
+            />
+            <View style={styles.linksRow}>
+              <Link href="/(auth)/forgot-password">
+                <Body style={styles.link}>Forgot password?</Body>
+              </Link>
+              <Link href="/(auth)/signup">
+                <Body style={styles.link}>Create account</Body>
+              </Link>
+            </View>
+          </Card>
+        </ScrollView>
+      </SafeAreaView>
+    </KeyboardAvoidingView>
   );
 }
 
 function createStyles(theme: Theme) {
   return StyleSheet.create({
+    keyboardAvoider: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
     safeArea: {
       flex: 1,
       backgroundColor: theme.colors.background,

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -1,6 +1,13 @@
 import { Link, router } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
-import { Alert, ScrollView, StyleSheet, View } from "react-native";
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  View,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
@@ -79,110 +86,120 @@ export default function SignupScreen() {
   };
 
   return (
-    <SafeAreaView style={styles.safeArea}>
-      <ScrollView
-        contentContainerStyle={styles.scrollContent}
-        keyboardShouldPersistTaps="handled"
-        showsVerticalScrollIndicator={false}
-      >
-        <Card style={styles.card}>
-          <View style={styles.logoContainer}>
-            <BrandLogo size={80} />
-          </View>
-          <Title style={styles.title}>Create your account</Title>
-          <View style={styles.section}>
-            <Subtitle style={styles.sectionTitle}>Account details</Subtitle>
-            <Body style={styles.sectionSubtitle}>
-              Sign in with your work email so we can keep your estimates in sync.
-            </Body>
-            <Input
-              autoCapitalize="none"
-              autoComplete="email"
-              autoCorrect={false}
-              keyboardType="email-address"
-              placeholder="you@example.com"
-              label="Email"
-              value={email}
-              onChangeText={setEmail}
-            />
-            <Input
-              autoCapitalize="none"
-              autoComplete="password"
-              placeholder="Create a password"
-              secureTextEntry
-              label="Password"
-              value={password}
-              onChangeText={setPassword}
-            />
-            <Input
-              autoCapitalize="none"
-              autoComplete="password"
-              placeholder="Confirm your password"
-              secureTextEntry
-              label="Confirm password"
-              value={confirmPassword}
-              onChangeText={setConfirmPassword}
-            />
-          </View>
+    <KeyboardAvoidingView
+      style={styles.keyboardAvoider}
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+      keyboardVerticalOffset={Platform.OS === "ios" ? 80 : 0}
+    >
+      <SafeAreaView style={styles.safeArea}>
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <Card style={styles.card}>
+            <View style={styles.logoContainer}>
+              <BrandLogo size={80} />
+            </View>
+            <Title style={styles.title}>Create your account</Title>
+            <View style={styles.section}>
+              <Subtitle style={styles.sectionTitle}>Account details</Subtitle>
+              <Body style={styles.sectionSubtitle}>
+                Sign in with your work email so we can keep your estimates in sync.
+              </Body>
+              <Input
+                autoCapitalize="none"
+                autoComplete="email"
+                autoCorrect={false}
+                keyboardType="email-address"
+                placeholder="you@example.com"
+                label="Email"
+                value={email}
+                onChangeText={setEmail}
+              />
+              <Input
+                autoCapitalize="none"
+                autoComplete="password"
+                placeholder="Create a password"
+                secureTextEntry
+                label="Password"
+                value={password}
+                onChangeText={setPassword}
+              />
+              <Input
+                autoCapitalize="none"
+                autoComplete="password"
+                placeholder="Confirm your password"
+                secureTextEntry
+                label="Confirm password"
+                value={confirmPassword}
+                onChangeText={setConfirmPassword}
+              />
+            </View>
 
-          <View style={styles.section}>
-            <Subtitle style={styles.sectionTitle}>Company profile</Subtitle>
-            <Body style={styles.sectionSubtitle}>
-              We’ll preload every estimate with this information. You can tweak it anytime in
-              Settings.
-            </Body>
-            <LogoPicker value={logoUri} onChange={setLogoUri} />
-            <Input
-              placeholder="Acme Landscaping"
-              label="Company name"
-              value={companyName}
-              onChangeText={setCompanyName}
-            />
-            <Input
-              placeholder="hello@acme.com"
-              keyboardType="email-address"
-              autoCapitalize="none"
-              label="Company email"
-              value={companyEmail}
-              onChangeText={setCompanyEmail}
-            />
-            <Input
-              placeholder="(555) 555-0199"
-              keyboardType="phone-pad"
-              label="Phone"
-              value={companyPhone}
-              onChangeText={setCompanyPhone}
-            />
-            <Input
-              placeholder="https://acme.com"
-              autoCapitalize="none"
-              label="Website"
-              value={companyWebsite}
-              onChangeText={setCompanyWebsite}
-            />
-            <Input
-              placeholder="123 Main St, Springfield"
-              label="Business address"
-              value={companyAddress}
-              onChangeText={setCompanyAddress}
-              multiline
-            />
-          </View>
+            <View style={styles.section}>
+              <Subtitle style={styles.sectionTitle}>Company profile</Subtitle>
+              <Body style={styles.sectionSubtitle}>
+                We’ll preload every estimate with this information. You can tweak it anytime in
+                Settings.
+              </Body>
+              <LogoPicker value={logoUri} onChange={setLogoUri} />
+              <Input
+                placeholder="Acme Landscaping"
+                label="Company name"
+                value={companyName}
+                onChangeText={setCompanyName}
+              />
+              <Input
+                placeholder="hello@acme.com"
+                keyboardType="email-address"
+                autoCapitalize="none"
+                label="Company email"
+                value={companyEmail}
+                onChangeText={setCompanyEmail}
+              />
+              <Input
+                placeholder="(555) 555-0199"
+                keyboardType="phone-pad"
+                label="Phone"
+                value={companyPhone}
+                onChangeText={setCompanyPhone}
+              />
+              <Input
+                placeholder="https://acme.com"
+                autoCapitalize="none"
+                label="Website"
+                value={companyWebsite}
+                onChangeText={setCompanyWebsite}
+              />
+              <Input
+                placeholder="123 Main St, Springfield"
+                label="Business address"
+                value={companyAddress}
+                onChangeText={setCompanyAddress}
+                multiline
+              />
+            </View>
 
-          <Button label="Sign up" onPress={handleSignup} loading={loading} />
-          <View style={styles.linksRow}>
-            <Link href="/(auth)/login">
-              <Body style={styles.link}>Already have an account?</Body>
-            </Link>
-          </View>
-        </Card>
-      </ScrollView>
-    </SafeAreaView>
+            <Button label="Sign up" onPress={handleSignup} loading={loading} />
+            <View style={styles.linksRow}>
+              <Link href="/(auth)/login">
+                <Body style={styles.link}>Already have an account?</Body>
+              </Link>
+            </View>
+          </Card>
+        </ScrollView>
+      </SafeAreaView>
+    </KeyboardAvoidingView>
   );
 }
 
 function createStyles(theme: Theme) {
   return StyleSheet.create({
+    keyboardAvoider: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
     safeArea: {
       flex: 1,
       backgroundColor: theme.colors.background,


### PR DESCRIPTION
## Summary
- wrap the login and signup screens in platform-aware `KeyboardAvoidingView` containers with iOS offsets
- keep the safe area and scroll configuration so the forms fill the screen and scroll smoothly without bouncing
- ensure every input remains inside the keyboard-aware layout to prevent the previous flicker/twitch

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e01129074c8323b5216037a7df47e8