### PR TITLE
Improve auth keyboard handling

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -44,6 +44,7 @@ export default function LoginScreen() {
   return (
     <SafeAreaView style={styles.safeArea}>
       <KeyboardAwareScrollView
+        style={styles.scrollView}
         enableOnAndroid
         keyboardShouldPersistTaps="handled"
         extraScrollHeight={24}
@@ -115,6 +116,9 @@ function createStyles(theme: Theme) {
       justifyContent: "center",
       paddingHorizontal: theme.spacing.xl,
       paddingVertical: theme.spacing.xl,
+    },
+    scrollView: {
+      flex: 1,
     },
     card: {
       gap: theme.spacing.lg,

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -86,6 +86,7 @@ export default function SignupScreen() {
   return (
     <SafeAreaView style={styles.safeArea}>
       <KeyboardAwareScrollView
+        style={styles.scrollView}
         enableOnAndroid
         keyboardShouldPersistTaps="handled"
         extraScrollHeight={24}
@@ -232,6 +233,9 @@ function createStyles(theme: Theme) {
       justifyContent: "center",
       paddingHorizontal: theme.spacing.xl,
       paddingVertical: theme.spacing.xl,
+    },
+    scrollView: {
+      flex: 1,
     },
     card: {
       gap: theme.spacing.xl,


### PR DESCRIPTION
## Summary
- ensure the login and signup screens use the keyboard-aware scroll view layout helpers
- give the keyboard-aware containers flex styles to avoid layout jumps while the keyboard is visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e01c64f0d08323ae7624e39a0591a3