### PR TITLE
Fix auth screen layout to prevent Android keyboard jitter

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -3,15 +3,13 @@ import { useMemo, useRef, useState } from "react";
 import {
   Alert,
   Keyboard,
-  KeyboardAvoidingView,
-  Platform,
+  ScrollView,
   StyleSheet,
   TextInput,
   TouchableWithoutFeedback,
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
 import { Body, Button, Card, Input, Subtitle, Title } from "../../components/ui";
@@ -52,74 +50,64 @@ export default function LoginScreen() {
 
   return (
     <SafeAreaView style={styles.safeArea}>
-      <KeyboardAvoidingView
-        style={styles.keyboardAvoiding}
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-        keyboardVerticalOffset={Platform.OS === "ios" ? 80 : 0}
-      >
-        <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-          <View style={styles.flex}>
-            <KeyboardAwareScrollView
-              style={styles.scrollView}
-              enableOnAndroid
-              keyboardShouldPersistTaps="handled"
-              extraScrollHeight={24}
-              contentContainerStyle={styles.scrollContent}
-              showsVerticalScrollIndicator={false}
-            >
-              <Card style={styles.card}>
-                <View style={styles.logoContainer}>
-                  <BrandLogo size={80} />
-                </View>
-                <Title style={styles.title}>Welcome back</Title>
-                <Subtitle style={styles.subtitle}>
-                  Sign in to manage estimates, customers, and your team from anywhere.
-                </Subtitle>
-                <Input
-                  ref={emailRef}
-                  autoCapitalize="none"
-                  autoComplete="email"
-                  autoCorrect={false}
-                  keyboardType="email-address"
-                  placeholder="you@example.com"
-                  label="Email"
-                  value={email}
-                  onChangeText={setEmail}
-                  returnKeyType="next"
-                  blurOnSubmit={false}
-                  onSubmitEditing={() => passwordRef.current?.focus()}
-                />
-                <Input
-                  ref={passwordRef}
-                  autoCapitalize="none"
-                  autoComplete="password"
-                  placeholder="••••••••"
-                  secureTextEntry
-                  label="Password"
-                  value={password}
-                  onChangeText={setPassword}
-                  returnKeyType="done"
-                  onSubmitEditing={handleLogin}
-                />
-                <Button
-                  label="Sign in"
-                  onPress={handleLogin}
-                  loading={loading}
-                  accessibilityLabel="Sign in to QuickQuote"
-                />
-                <View style={styles.linksRow}>
-                  <Link href="/(auth)/forgot-password">
-                    <Body style={styles.link}>Forgot password?</Body>
-                  </Link>
-                  <Link href="/(auth)/signup">
-                    <Body style={styles.link}>Create account</Body>
-                  </Link>
-                </View>
-              </Card>
-            </KeyboardAwareScrollView>
-          </View>
-        </TouchableWithoutFeedback>
-      </KeyboardAvoidingView>
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <Card style={styles.card}>
+            <View style={styles.logoContainer}>
+              <BrandLogo size={80} />
+            </View>
+            <Title style={styles.title}>Welcome back</Title>
+            <Subtitle style={styles.subtitle}>
+              Sign in to manage estimates, customers, and your team from anywhere.
+            </Subtitle>
+            <Input
+              ref={emailRef}
+              autoCapitalize="none"
+              autoComplete="email"
+              autoCorrect={false}
+              keyboardType="email-address"
+              placeholder="you@example.com"
+              label="Email"
+              value={email}
+              onChangeText={setEmail}
+              returnKeyType="next"
+              blurOnSubmit={false}
+              onSubmitEditing={() => passwordRef.current?.focus()}
+            />
+            <Input
+              ref={passwordRef}
+              autoCapitalize="none"
+              autoComplete="password"
+              placeholder="••••••••"
+              secureTextEntry
+              label="Password"
+              value={password}
+              onChangeText={setPassword}
+              returnKeyType="done"
+              blurOnSubmit={false}
+              onSubmitEditing={handleLogin}
+            />
+            <Button
+              label="Sign in"
+              onPress={handleLogin}
+              loading={loading}
+              accessibilityLabel="Sign in to QuickQuote"
+            />
+            <View style={styles.linksRow}>
+              <Link href="/(auth)/forgot-password">
+                <Body style={styles.link}>Forgot password?</Body>
+              </Link>
+              <Link href="/(auth)/signup">
+                <Body style={styles.link}>Create account</Body>
+              </Link>
+            </View>
+          </Card>
+        </ScrollView>
+      </TouchableWithoutFeedback>
     </SafeAreaView>
   );
 }
@@ -130,20 +118,11 @@ function createStyles(theme: Theme) {
       flex: 1,
       backgroundColor: theme.colors.background,
     },
-    keyboardAvoiding: {
-      flex: 1,
-    },
-    flex: {
-      flex: 1,
-    },
     scrollContent: {
       flexGrow: 1,
       justifyContent: "center",
       paddingHorizontal: theme.spacing.xl,
       paddingVertical: theme.spacing.xl,
-    },
-    scrollView: {
-      flex: 1,
     },
     card: {
       gap: theme.spacing.lg,

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -3,15 +3,13 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
   Keyboard,
-  KeyboardAvoidingView,
-  Platform,
+  ScrollView,
   StyleSheet,
   TextInput,
   TouchableWithoutFeedback,
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
 import LogoPicker from "../../components/LogoPicker";
@@ -94,149 +92,138 @@ export default function SignupScreen() {
 
   return (
     <SafeAreaView style={styles.safeArea}>
-      <KeyboardAvoidingView
-        style={styles.keyboardAvoiding}
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-        keyboardVerticalOffset={Platform.OS === "ios" ? 80 : 0}
-      >
-        <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-          <View style={styles.flex}>
-            <KeyboardAwareScrollView
-              style={styles.scrollView}
-              enableOnAndroid
-              keyboardShouldPersistTaps="handled"
-              extraScrollHeight={24}
-              contentContainerStyle={styles.scrollContent}
-              showsVerticalScrollIndicator={false}
-            >
-              <Card style={styles.card}>
-                <View style={styles.logoContainer}>
-                  <BrandLogo size={80} />
-                </View>
-                <Title style={styles.title}>Create your account</Title>
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <Card style={styles.card}>
+            <View style={styles.logoContainer}>
+              <BrandLogo size={80} />
+            </View>
+            <Title style={styles.title}>Create your account</Title>
 
-                <View style={styles.section}>
-                  <Subtitle style={styles.sectionTitle}>Account details</Subtitle>
-                  <Body style={styles.sectionSubtitle}>
-                    Sign in with your work email so we can keep your estimates in sync.
-                  </Body>
-                  <Input
-                    ref={emailRef}
-                    autoCapitalize="none"
-                    autoComplete="email"
-                    autoCorrect={false}
-                    keyboardType="email-address"
-                    placeholder="you@example.com"
-                    label="Email"
-                    value={email}
-                    onChangeText={setEmail}
-                    returnKeyType="next"
-                    blurOnSubmit={false}
-                    onSubmitEditing={() => passwordRef.current?.focus()}
-                  />
-                  <Input
-                    ref={passwordRef}
-                    autoCapitalize="none"
-                    autoComplete="password"
-                    placeholder="Create a password"
-                    secureTextEntry
-                    label="Password"
-                    value={password}
-                    onChangeText={setPassword}
-                    returnKeyType="next"
-                    blurOnSubmit={false}
-                    onSubmitEditing={() => confirmPasswordRef.current?.focus()}
-                  />
-                  <Input
-                    ref={confirmPasswordRef}
-                    autoCapitalize="none"
-                    autoComplete="password"
-                    placeholder="Confirm your password"
-                    secureTextEntry
-                    label="Confirm password"
-                    value={confirmPassword}
-                    onChangeText={setConfirmPassword}
-                    returnKeyType="next"
-                    blurOnSubmit={false}
-                    onSubmitEditing={() => companyNameRef.current?.focus()}
-                  />
-                </View>
+            <View style={styles.section}>
+              <Subtitle style={styles.sectionTitle}>Account details</Subtitle>
+              <Body style={styles.sectionSubtitle}>
+                Sign in with your work email so we can keep your estimates in sync.
+              </Body>
+              <Input
+                ref={emailRef}
+                autoCapitalize="none"
+                autoComplete="email"
+                autoCorrect={false}
+                keyboardType="email-address"
+                placeholder="you@example.com"
+                label="Email"
+                value={email}
+                onChangeText={setEmail}
+                returnKeyType="next"
+                blurOnSubmit={false}
+                onSubmitEditing={() => passwordRef.current?.focus()}
+              />
+              <Input
+                ref={passwordRef}
+                autoCapitalize="none"
+                autoComplete="password"
+                placeholder="Create a password"
+                secureTextEntry
+                label="Password"
+                value={password}
+                onChangeText={setPassword}
+                returnKeyType="next"
+                blurOnSubmit={false}
+                onSubmitEditing={() => confirmPasswordRef.current?.focus()}
+              />
+              <Input
+                ref={confirmPasswordRef}
+                autoCapitalize="none"
+                autoComplete="password"
+                placeholder="Confirm your password"
+                secureTextEntry
+                label="Confirm password"
+                value={confirmPassword}
+                onChangeText={setConfirmPassword}
+                returnKeyType="next"
+                blurOnSubmit={false}
+                onSubmitEditing={() => companyNameRef.current?.focus()}
+              />
+            </View>
 
-                <View style={styles.section}>
-                  <Subtitle style={styles.sectionTitle}>Company profile</Subtitle>
-                  <Body style={styles.sectionSubtitle}>
-                    We’ll preload every estimate with this information. You can tweak it anytime in
-                    Settings.
-                  </Body>
-                  <LogoPicker value={logoUri} onChange={setLogoUri} />
-                  <Input
-                    ref={companyNameRef}
-                    placeholder="Acme Landscaping"
-                    label="Company name"
-                    value={companyName}
-                    onChangeText={setCompanyName}
-                    returnKeyType="next"
-                    blurOnSubmit={false}
-                    onSubmitEditing={() => companyEmailRef.current?.focus()}
-                  />
-                  <Input
-                    ref={companyEmailRef}
-                    placeholder="hello@acme.com"
-                    keyboardType="email-address"
-                    autoCapitalize="none"
-                    label="Company email"
-                    value={companyEmail}
-                    onChangeText={setCompanyEmail}
-                    returnKeyType="next"
-                    blurOnSubmit={false}
-                    onSubmitEditing={() => companyPhoneRef.current?.focus()}
-                  />
-                  <Input
-                    ref={companyPhoneRef}
-                    placeholder="(555) 555-0199"
-                    keyboardType="phone-pad"
-                    label="Phone"
-                    value={companyPhone}
-                    onChangeText={setCompanyPhone}
-                    returnKeyType="next"
-                    blurOnSubmit={false}
-                    onSubmitEditing={() => companyWebsiteRef.current?.focus()}
-                  />
-                  <Input
-                    ref={companyWebsiteRef}
-                    placeholder="https://acme.com"
-                    autoCapitalize="none"
-                    label="Website"
-                    value={companyWebsite}
-                    onChangeText={setCompanyWebsite}
-                    returnKeyType="next"
-                    blurOnSubmit={false}
-                    onSubmitEditing={() => companyAddressRef.current?.focus()}
-                  />
-                  <Input
-                    ref={companyAddressRef}
-                    placeholder="123 Main St, Springfield"
-                    label="Business address"
-                    value={companyAddress}
-                    onChangeText={setCompanyAddress}
-                    multiline
-                    returnKeyType="done"
-                    blurOnSubmit
-                    onSubmitEditing={handleSignup}
-                  />
-                </View>
+            <View style={styles.section}>
+              <Subtitle style={styles.sectionTitle}>Company profile</Subtitle>
+              <Body style={styles.sectionSubtitle}>
+                We’ll preload every estimate with this information. You can tweak it anytime in
+                Settings.
+              </Body>
+              <LogoPicker value={logoUri} onChange={setLogoUri} />
+              <Input
+                ref={companyNameRef}
+                placeholder="Acme Landscaping"
+                label="Company name"
+                value={companyName}
+                onChangeText={setCompanyName}
+                returnKeyType="next"
+                blurOnSubmit={false}
+                onSubmitEditing={() => companyEmailRef.current?.focus()}
+              />
+              <Input
+                ref={companyEmailRef}
+                placeholder="hello@acme.com"
+                keyboardType="email-address"
+                autoCapitalize="none"
+                label="Company email"
+                value={companyEmail}
+                onChangeText={setCompanyEmail}
+                returnKeyType="next"
+                blurOnSubmit={false}
+                onSubmitEditing={() => companyPhoneRef.current?.focus()}
+              />
+              <Input
+                ref={companyPhoneRef}
+                placeholder="(555) 555-0199"
+                keyboardType="phone-pad"
+                label="Phone"
+                value={companyPhone}
+                onChangeText={setCompanyPhone}
+                returnKeyType="next"
+                blurOnSubmit={false}
+                onSubmitEditing={() => companyWebsiteRef.current?.focus()}
+              />
+              <Input
+                ref={companyWebsiteRef}
+                placeholder="https://acme.com"
+                autoCapitalize="none"
+                label="Website"
+                value={companyWebsite}
+                onChangeText={setCompanyWebsite}
+                returnKeyType="next"
+                blurOnSubmit={false}
+                onSubmitEditing={() => companyAddressRef.current?.focus()}
+              />
+              <Input
+                ref={companyAddressRef}
+                placeholder="123 Main St, Springfield"
+                label="Business address"
+                value={companyAddress}
+                onChangeText={setCompanyAddress}
+                multiline
+                returnKeyType="done"
+                blurOnSubmit={false}
+                onSubmitEditing={handleSignup}
+              />
+            </View>
 
-                <Button label="Sign up" onPress={handleSignup} loading={loading} />
-                <View style={styles.linksRow}>
-                  <Link href="/(auth)/login">
-                    <Body style={styles.link}>Already have an account?</Body>
-                  </Link>
-                </View>
-              </Card>
-            </KeyboardAwareScrollView>
-          </View>
-        </TouchableWithoutFeedback>
-      </KeyboardAvoidingView>
+            <Button label="Sign up" onPress={handleSignup} loading={loading} />
+            <View style={styles.linksRow}>
+              <Link href="/(auth)/login">
+                <Body style={styles.link}>Already have an account?</Body>
+              </Link>
+            </View>
+          </Card>
+        </ScrollView>
+      </TouchableWithoutFeedback>
     </SafeAreaView>
   );
 }
@@ -247,20 +234,11 @@ function createStyles(theme: Theme) {
       flex: 1,
       backgroundColor: theme.colors.background,
     },
-    keyboardAvoiding: {
-      flex: 1,
-    },
-    flex: {
-      flex: 1,
-    },
     scrollContent: {
       flexGrow: 1,
       justifyContent: "center",
       paddingHorizontal: theme.spacing.xl,
       paddingVertical: theme.spacing.xl,
-    },
-    scrollView: {
-      flex: 1,
     },
     card: {
       gap: theme.spacing.xl,


### PR DESCRIPTION
## Summary
- replace the auth screen layout wrappers with a SafeAreaView + ScrollView stack to prevent keyboard jumping
- preserve input focus handling so the Android keyboard stays open and dismisses on background tap

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e024693f848323b3318f19f31b6bc7