### PR TITLE
Unify estimate creation flow into edit screen

### DIFF
--- a/app/(tabs)/estimates/create-view.tsx
+++ b/app/(tabs)/estimates/create-view.tsx
@@ -98,7 +98,7 @@ type PersistedEstimateRecord = {
 
 type PersistedEstimateItem = EstimateItemRecord;
 
-type SavedEstimateContext = {
+export type SavedEstimateContext = {
   estimate: PersistedEstimateRecord;
   items: PersistedEstimateItem[];
   customer: CustomerOption;
@@ -119,6 +119,12 @@ type SavedEstimateContext = {
 type FormErrors = {
   customer?: string;
   lineItems?: string;
+};
+
+type CreateEstimateViewProps = {
+  estimateId: string;
+  onCreated: (context: SavedEstimateContext) => void;
+  onCancel: () => void;
 };
 
 function formatCurrency(value: number): string {
@@ -460,7 +466,11 @@ function createStyles(theme: Theme) {
   });
 }
 
-export default function NewEstimateScreen() {
+export default function CreateEstimateView({
+  estimateId,
+  onCreated,
+  onCancel,
+}: CreateEstimateViewProps) {
   const { user, session } = useAuth();
   const { settings } = useSettings();
   const { openEditor } = useItemEditor();
@@ -479,7 +489,7 @@ export default function NewEstimateScreen() {
     return Math.round(rate * 100) / 100;
   }, [settings.taxRate]);
 
-  const draftEstimateIdRef = useRef<string>(uuidv4());
+  const draftEstimateIdRef = useRef<string>(estimateId);
 
   const [customerQuery, setCustomerQuery] = useState("");
   const [customerResults, setCustomerResults] = useState<CustomerOption[]>([]);
@@ -984,13 +994,11 @@ export default function NewEstimateScreen() {
         text: "Discard",
         style: "destructive",
         onPress: () => {
-          if (typeof navigation.back === "function") {
-            navigation.back();
-          }
+          onCancel();
         },
       },
     ]);
-  }, [navigation]);
+  }, [onCancel]);
 
   const saveEstimate = useCallback(async (): Promise<SavedEstimateContext | null> => {
     if (!userId) {
@@ -1337,13 +1345,11 @@ export default function NewEstimateScreen() {
       if (!context) {
         return;
       }
-      if (typeof navigation.replace === "function") {
-        navigation.replace(`/(tabs)/estimates/${context.estimate.id}`);
-      }
+      onCreated(context);
     } finally {
       setSaving(false);
     }
-  }, [navigation, saveEstimate, saving]);
+  }, [onCreated, saveEstimate, saving]);
 
   return (
     <SafeAreaView style={styles.safeArea}>

--- a/app/(tabs)/estimates/index.tsx
+++ b/app/(tabs)/estimates/index.tsx
@@ -211,6 +211,10 @@ export default function EstimatesScreen() {
     setLoading(false);
   }, [fetchEstimates]);
 
+  const handleCreateEstimate = useCallback(() => {
+    router.push({ pathname: "/(tabs)/estimates/[id]", params: { mode: "new" } });
+  }, []);
+
   const filteredEstimates = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
 
@@ -357,7 +361,7 @@ export default function EstimatesScreen() {
                   </Text>
                   <Button
                     label="Create Estimate"
-                    onPress={() => router.push("/(tabs)/estimates/new")}
+                    onPress={handleCreateEstimate}
                     accessibilityLabel="Create a new estimate"
                   />
                 </View>
@@ -375,17 +379,19 @@ export default function EstimatesScreen() {
           contentContainerStyle={styles.listContent}
           keyboardShouldPersistTaps="handled"
         />
-        <View style={styles.primaryAction}>
-          <Button
-            label="Create Estimate"
-            onPress={() => router.push("/(tabs)/estimates/new")}
-            accessibilityLabel="Create a new estimate"
-          />
-        </View>
+        {filteredEstimates.length > 0 ? (
+          <View style={styles.createAction}>
+            <Button
+              label="Create Estimate"
+              onPress={handleCreateEstimate}
+              accessibilityLabel="Create a new estimate"
+            />
+          </View>
+        ) : null}
         {showFab ? (
           <FAB
             icon={<Feather name="plus" size={24} color={theme.colors.primaryText} />}
-            onPress={() => router.push("/(tabs)/estimates/new")}
+            onPress={handleCreateEstimate}
             accessibilityLabel="Create a new estimate"
             style={styles.fab}
           />
@@ -510,11 +516,9 @@ function createStyles(theme: Theme) {
     statusBadge: {
       backgroundColor: theme.colors.accentSoft,
     },
-    primaryAction: {
-      position: "absolute",
-      bottom: theme.spacing.xl,
-      left: theme.spacing.xl,
-      right: theme.spacing.xl,
+    createAction: {
+      paddingHorizontal: theme.spacing.xl,
+      paddingBottom: theme.spacing.lg,
     },
     fab: {
       position: "absolute",

--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -559,7 +559,7 @@ export default function Home() {
       <View style={[styles.footer, { paddingBottom: bottomPadding }]}>
         <Button
           label="Create Estimate"
-          onPress={() => router.push("/(tabs)/estimates/new")}
+          onPress={() => router.push({ pathname: "/(tabs)/estimates/[id]", params: { mode: "new" } })}
         />
       </View>
     </View>

--- a/docs/final-cleanup-report.md
+++ b/docs/final-cleanup-report.md
@@ -14,7 +14,7 @@
 - Queue helpers persist pending changes, enabling later sync attempts. 【F:lib/sqlite.ts†L262-L289】
 - Root layout initializes the database and retries sync whenever the app becomes active to flush queued work. 【F:app/_layout.tsx†L131-L170】
 - Customer creation writes to SQLite immediately, queues the mutation, and triggers a sync when connectivity allows. 【F:components/CustomerForm.tsx†L41-L95】
-- Estimate creation/update mirrors the same pattern for estimates, line items, and photos, including retrying sync. 【F:app/(tabs)/estimates/new.tsx†L1120-L1335】
+- Estimate creation/update mirrors the same pattern for estimates, line items, and photos, including retrying sync. 【F:app/(tabs)/estimates/create-view.tsx†L1080-L1336】
 
 ## Soft Delete Coverage
 - Customer deletions soft-delete related estimates, line items, and photos, queue the mutations, and trigger sync. 【F:app/(tabs)/customers.tsx†L288-L382】


### PR DESCRIPTION
## Summary
- move the estimate creation form into a reusable component consumed by the unified estimate screen
- route all create actions to the shared estimate route and streamline the list screen actions
- update tests and documentation for the new creation flow

## Testing
- npm test -- --runTestsByPath __tests__/newEstimate.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e1976d30008323816c4ef995489508