### PR TITLE
Add sharing actions to new estimate view

### DIFF
--- a/__tests__/newEstimate.test.tsx
+++ b/__tests__/newEstimate.test.tsx
@@ -202,7 +202,7 @@ describe("CreateEstimateView", () => {
 
     const saveButton = screen
       .UNSAFE_getAllByType(Button)
-      .find((instance) => instance.props.label === "Save & Continue");
+      .find((instance) => instance.props.label === "Save Draft");
     await act(async () => {
       await saveButton?.props.onPress?.();
     });
@@ -297,7 +297,7 @@ describe("CreateEstimateView", () => {
     });
     const saveButton = screen
       .UNSAFE_getAllByType(Button)
-      .find((instance) => instance.props.label === "Save & Continue");
+      .find((instance) => instance.props.label === "Save Draft");
     await act(async () => {
       await saveButton?.props.onPress?.();
     });


### PR DESCRIPTION
## Summary
- add save draft, preview, send, and delete controls directly to the new estimate flow
- reuse PDF generation and delivery logic so drafts can be previewed or shared without opening the edit screen
- update the new estimate test expectations for the revised primary action

## Testing
- npm test -- --runTestsByPath __tests__/newEstimate.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e19ea0b1088323a9b1a87c26eadaf7