### PR TITLE
Refactor auth keyboard handling with KeyboardStickyView

### DIFF
--- a/app/(auth)/forgot-password.tsx
+++ b/app/(auth)/forgot-password.tsx
@@ -1,6 +1,8 @@
 import { Link } from "expo-router";
 import { useMemo, useState } from "react";
-import { Alert, KeyboardAvoidingView, Platform, StyleSheet, View } from "react-native";
+import { Alert, StyleSheet, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { KeyboardStickyView } from "react-native-keyboard-controller";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
 import { Body, Button, Card, Input, Subtitle, Title } from "../../components/ui";
@@ -41,41 +43,44 @@ export default function ForgotPasswordScreen() {
   };
 
   return (
-    <KeyboardAvoidingView
-      behavior={Platform.select({ ios: "padding", android: undefined })}
-      style={styles.container}
-    >
-      <Card style={styles.card}>
-        <View style={styles.logoContainer}>
-          <BrandLogo size={80} />
-        </View>
-        <Title style={styles.title}>Reset your password</Title>
-        <Subtitle style={styles.subtitle}>
-          Enter the email linked to your account and we'll send reset instructions.
-        </Subtitle>
-        <Input
-          autoCapitalize="none"
-          autoComplete="email"
-          autoCorrect={false}
-          keyboardType="email-address"
-          placeholder="you@example.com"
-          label="Email"
-          value={email}
-          onChangeText={setEmail}
-        />
-        <Button label="Send reset link" onPress={handleReset} loading={loading} />
-        <View style={styles.linksRow}>
-          <Link href="/(auth)/login">
-            <Body style={styles.link}>Back to sign in</Body>
-          </Link>
-        </View>
-      </Card>
-    </KeyboardAvoidingView>
+    <SafeAreaView style={styles.safeArea}>
+      <KeyboardStickyView style={styles.container}>
+        <Card style={styles.card}>
+          <View style={styles.logoContainer}>
+            <BrandLogo size={80} />
+          </View>
+          <Title style={styles.title}>Reset your password</Title>
+          <Subtitle style={styles.subtitle}>
+            Enter the email linked to your account and we'll send reset instructions.
+          </Subtitle>
+          <Input
+            autoCapitalize="none"
+            autoComplete="email"
+            autoCorrect={false}
+            keyboardType="email-address"
+            placeholder="you@example.com"
+            label="Email"
+            value={email}
+            onChangeText={setEmail}
+          />
+          <Button label="Send reset link" onPress={handleReset} loading={loading} />
+          <View style={styles.linksRow}>
+            <Link href="/(auth)/login">
+              <Body style={styles.link}>Back to sign in</Body>
+            </Link>
+          </View>
+        </Card>
+      </KeyboardStickyView>
+    </SafeAreaView>
   );
 }
 
 function createStyles(theme: Theme) {
   return StyleSheet.create({
+    safeArea: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
     container: {
       flex: 1,
       backgroundColor: theme.colors.background,

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,15 +1,8 @@
 import { Link, router } from "expo-router";
 import { useMemo, useRef, useState } from "react";
-import {
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  StyleSheet,
-  TextInput,
-  View,
-} from "react-native";
+import { Alert, ScrollView, StyleSheet, TextInput, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { KeyboardStickyView } from "react-native-keyboard-controller";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
 import { Body, Button, Card, Input, Subtitle, Title } from "../../components/ui";
@@ -48,11 +41,7 @@ export default function LoginScreen() {
 
   return (
     <SafeAreaView style={styles.safeArea}>
-      <KeyboardAvoidingView
-        style={{ flex: 1 }}
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-        keyboardVerticalOffset={Platform.OS === "ios" ? 80 : 0}
-      >
+      <KeyboardStickyView style={styles.keyboard}>
         <ScrollView
           contentContainerStyle={styles.scrollContent}
           keyboardShouldPersistTaps="handled"
@@ -104,7 +93,7 @@ export default function LoginScreen() {
             </View>
           </Card>
         </ScrollView>
-      </KeyboardAvoidingView>
+      </KeyboardStickyView>
     </SafeAreaView>
   );
 }
@@ -114,6 +103,9 @@ function createStyles(theme: Theme) {
     safeArea: {
       flex: 1,
       backgroundColor: theme.colors.background,
+    },
+    keyboard: {
+      flex: 1,
     },
     scrollContent: {
       flexGrow: 1,

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -1,15 +1,7 @@
 import { Link, router } from "expo-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ComponentProps } from "react";
-import {
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  StyleSheet,
-  TextInput,
-  View,
-} from "react-native";
+import { Alert, ScrollView, StyleSheet, TextInput, View } from "react-native";
 import type {
   KeyboardTypeOptions,
   ReturnKeyTypeOptions,
@@ -18,6 +10,7 @@ import type {
   ViewStyle,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { KeyboardStickyView } from "react-native-keyboard-controller";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
 import LogoPicker from "../../components/LogoPicker";
@@ -95,14 +88,10 @@ export default function SignupScreen() {
   };
 
   return (
-    <KeyboardAvoidingView
-      style={styles.root}
-      behavior={Platform.OS === "ios" ? "padding" : "height"}
-      keyboardVerticalOffset={Platform.OS === "ios" ? 64 : 0}
-    >
-      <SafeAreaView style={styles.root}>
+    <SafeAreaView style={styles.root}>
+      <KeyboardStickyView style={styles.keyboard}>
         <ScrollView
-          style={styles.root}
+          style={styles.scroll}
           contentContainerStyle={styles.scrollContent}
           keyboardDismissMode="on-drag"
           keyboardShouldPersistTaps="always"
@@ -228,14 +217,16 @@ export default function SignupScreen() {
 
           <View style={{ height: 24 }} />
         </ScrollView>
-      </SafeAreaView>
-    </KeyboardAvoidingView>
+      </KeyboardStickyView>
+    </SafeAreaView>
   );
 }
 
 function createStyles(theme: Theme) {
   return StyleSheet.create({
     root: { flex: 1, backgroundColor: theme.colors.background },
+    keyboard: { flex: 1 },
+    scroll: { flex: 1 },
     scrollContent: {
       paddingHorizontal: theme.spacing.xl,
       paddingVertical: theme.spacing.xl,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -9,6 +9,7 @@ import {
   View,
 } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
+import { KeyboardProvider } from "react-native-keyboard-controller";
 import { AuthProvider, useAuth } from "../context/AuthContext";
 import { SettingsProvider } from "../context/SettingsContext";
 import { initLocalDB } from "../lib/sqlite";
@@ -160,11 +161,13 @@ export default function RootLayout() {
   return (
     <ThemeProvider>
       <SafeAreaProvider>
-        <SettingsProvider>
-          <AuthProvider>
-            <RootNavigator />
-          </AuthProvider>
-        </SettingsProvider>
+        <KeyboardProvider statusBarTranslucent navigationBarTranslucent>
+          <SettingsProvider>
+            <AuthProvider>
+              <RootNavigator />
+            </AuthProvider>
+          </SettingsProvider>
+        </KeyboardProvider>
       </SafeAreaProvider>
     </ThemeProvider>
   );


### PR DESCRIPTION
## Summary
- replace keyboard avoiding layouts on the auth screens with KeyboardStickyView for smoother mobile keyboard behavior
- wrap the app layout in KeyboardProvider so the new sticky views receive keyboard context

## Testing
- npm run typecheck *(fails: Cannot find name 'router' in app/(tabs)/estimates/[id].tsx:2223)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b4a62e2883239dbe5b24106fb8a2