### PR TITLE
Fix keyboard collapsing on auth screens

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,21 +1,12 @@
 import { Link, router } from "expo-router";
 import { useMemo, useRef, useState } from "react";
-import {
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  StyleSheet,
-  TextInput,
-  Keyboard,
-  View,
-} from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { Alert, StyleSheet, TextInput, View } from "react-native";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
 import { Body, Button, Card, Input, Subtitle, Title } from "../../components/ui";
 import { Theme } from "../../theme";
 import { useThemeContext } from "../../theme/ThemeProvider";
+import { ScreenWrapper } from "../../components/ScreenWrapper";
 
 export default function LoginScreen() {
   const [email, setEmail] = useState("");
@@ -49,81 +40,67 @@ export default function LoginScreen() {
   };
 
   return (
-    <SafeAreaView style={styles.safeArea}>
-      <KeyboardAvoidingView
-        style={styles.flex}
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
-        keyboardVerticalOffset={Platform.OS === "ios" ? 80 : 0}
-      >
-        <ScrollView
-            contentContainerStyle={styles.scrollContent}
-            keyboardShouldPersistTaps="always"
-            showsVerticalScrollIndicator={false}
-          >
-            <Card style={styles.card}>
-              <View style={styles.logoContainer}>
-                <BrandLogo size={80} />
-              </View>
+    <ScreenWrapper>
+      <View style={styles.content}>
+        <Card style={styles.card}>
+          <View style={styles.logoContainer}>
+            <BrandLogo size={80} />
+          </View>
 
-              <Title style={styles.title}>Welcome back</Title>
-              <Subtitle style={styles.subtitle}>
-                Sign in to manage estimates, customers, and your team from anywhere.
-              </Subtitle>
+          <Title style={styles.title}>Welcome back</Title>
+          <Subtitle style={styles.subtitle}>
+            Sign in to manage estimates, customers, and your team from anywhere.
+          </Subtitle>
 
-              <Input
-                ref={emailRef}
-                autoCapitalize="none"
-                autoComplete="email"
-                autoCorrect={false}
-                keyboardType="email-address"
-                placeholder="you@example.com"
-                label="Email"
-                value={email}
-                onChangeText={setEmail}
-                returnKeyType="next"
-                blurOnSubmit={false}
-                onSubmitEditing={() => passwordRef.current?.focus()}
-              />
+          <Input
+            ref={emailRef}
+            autoCapitalize="none"
+            autoComplete="email"
+            autoCorrect={false}
+            keyboardType="email-address"
+            placeholder="you@example.com"
+            label="Email"
+            value={email}
+            onChangeText={setEmail}
+            returnKeyType="next"
+            blurOnSubmit={false}
+            onSubmitEditing={() => passwordRef.current?.focus()}
+          />
 
-              <Input
-                ref={passwordRef}
-                autoCapitalize="none"
-                autoComplete="password"
-                placeholder="••••••••"
-                secureTextEntry
-                label="Password"
-                value={password}
-                onChangeText={setPassword}
-                returnKeyType="done"
-                onSubmitEditing={handleLogin}
-              />
+          <Input
+            ref={passwordRef}
+            autoCapitalize="none"
+            autoComplete="password"
+            placeholder="••••••••"
+            secureTextEntry
+            label="Password"
+            value={password}
+            onChangeText={setPassword}
+            returnKeyType="done"
+            onSubmitEditing={handleLogin}
+          />
 
-              <Button label="Sign in" onPress={handleLogin} loading={loading} />
+          <Button label="Sign in" onPress={handleLogin} loading={loading} />
 
-              <View style={styles.linksRow}>
-                <Link href="/(auth)/forgot-password">
-                  <Body style={styles.link}>Forgot password?</Body>
-                </Link>
-                <Link href="/(auth)/signup">
-                  <Body style={styles.link}>Create account</Body>
-                </Link>
-              </View>
-            </Card>
-          </ScrollView>
-      </KeyboardAvoidingView>
-    </SafeAreaView>
+          <View style={styles.linksRow}>
+            <Link href="/(auth)/forgot-password">
+              <Body style={styles.link}>Forgot password?</Body>
+            </Link>
+            <Link href="/(auth)/signup">
+              <Body style={styles.link}>Create account</Body>
+            </Link>
+          </View>
+        </Card>
+      </View>
+    </ScreenWrapper>
   );
 }
 
 function createStyles(theme: Theme) {
   return StyleSheet.create({
-    flex: { flex: 1 },
-    safeArea: { flex: 1, backgroundColor: theme.colors.background },
-    scrollContent: {
-      flexGrow: 1,
+    content: {
+      flex: 1,
       justifyContent: "center",
-      paddingHorizontal: theme.spacing.xl,
-      paddingVertical: theme.spacing.xl,
       backgroundColor: theme.colors.background,
     },
     card: { gap: theme.spacing.lg },

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -1,21 +1,12 @@
 import { Link, router } from "expo-router";
 import { useMemo, useRef, useState } from "react";
-import {
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  StyleSheet,
-  TextInput,
-  Keyboard,
-  View,
-} from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { Alert, StyleSheet, TextInput, View } from "react-native";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
 import { Body, Button, Card, Input, Subtitle, Title } from "../../components/ui";
 import { Theme } from "../../theme";
 import { useThemeContext } from "../../theme/ThemeProvider";
+import { ScreenWrapper } from "../../components/ScreenWrapper";
 
 export default function LoginScreen() {
   const [email, setEmail] = useState("");
@@ -49,81 +40,67 @@ export default function LoginScreen() {
   };
 
   return (
-    <SafeAreaView style={styles.safeArea}>
-      <KeyboardAvoidingView
-        style={styles.flex}
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
-        keyboardVerticalOffset={Platform.OS === "ios" ? 80 : 0}
-      >
-          <ScrollView
-            contentContainerStyle={styles.scrollContent}
-            keyboardShouldPersistTaps="always"
-            showsVerticalScrollIndicator={false}
-          >
-            <Card style={styles.card}>
-              <View style={styles.logoContainer}>
-                <BrandLogo size={80} />
-              </View>
+    <ScreenWrapper>
+      <View style={styles.content}>
+        <Card style={styles.card}>
+          <View style={styles.logoContainer}>
+            <BrandLogo size={80} />
+          </View>
 
-              <Title style={styles.title}>Welcome back</Title>
-              <Subtitle style={styles.subtitle}>
-                Sign in to manage estimates, customers, and your team from anywhere.
-              </Subtitle>
+          <Title style={styles.title}>Welcome back</Title>
+          <Subtitle style={styles.subtitle}>
+            Sign in to manage estimates, customers, and your team from anywhere.
+          </Subtitle>
 
-              <Input
-                ref={emailRef}
-                autoCapitalize="none"
-                autoComplete="email"
-                autoCorrect={false}
-                keyboardType="email-address"
-                placeholder="you@example.com"
-                label="Email"
-                value={email}
-                onChangeText={setEmail}
-                returnKeyType="next"
-                blurOnSubmit={false}
-                onSubmitEditing={() => passwordRef.current?.focus()}
-              />
+          <Input
+            ref={emailRef}
+            autoCapitalize="none"
+            autoComplete="email"
+            autoCorrect={false}
+            keyboardType="email-address"
+            placeholder="you@example.com"
+            label="Email"
+            value={email}
+            onChangeText={setEmail}
+            returnKeyType="next"
+            blurOnSubmit={false}
+            onSubmitEditing={() => passwordRef.current?.focus()}
+          />
 
-              <Input
-                ref={passwordRef}
-                autoCapitalize="none"
-                autoComplete="password"
-                placeholder="••••••••"
-                secureTextEntry
-                label="Password"
-                value={password}
-                onChangeText={setPassword}
-                returnKeyType="done"
-                onSubmitEditing={handleLogin}
-              />
+          <Input
+            ref={passwordRef}
+            autoCapitalize="none"
+            autoComplete="password"
+            placeholder="••••••••"
+            secureTextEntry
+            label="Password"
+            value={password}
+            onChangeText={setPassword}
+            returnKeyType="done"
+            onSubmitEditing={handleLogin}
+          />
 
-              <Button label="Sign in" onPress={handleLogin} loading={loading} />
+          <Button label="Sign in" onPress={handleLogin} loading={loading} />
 
-              <View style={styles.linksRow}>
-                <Link href="/(auth)/forgot-password">
-                  <Body style={styles.link}>Forgot password?</Body>
-                </Link>
-                <Link href="/(auth)/signup">
-                  <Body style={styles.link}>Create account</Body>
-                </Link>
-              </View>
-            </Card>
-          </ScrollView>
-      </KeyboardAvoidingView>
-    </SafeAreaView>
+          <View style={styles.linksRow}>
+            <Link href="/(auth)/forgot-password">
+              <Body style={styles.link}>Forgot password?</Body>
+            </Link>
+            <Link href="/(auth)/signup">
+              <Body style={styles.link}>Create account</Body>
+            </Link>
+          </View>
+        </Card>
+      </View>
+    </ScreenWrapper>
   );
 }
 
 function createStyles(theme: Theme) {
   return StyleSheet.create({
-    flex: { flex: 1 },
-    safeArea: { flex: 1, backgroundColor: theme.colors.background },
-    scrollContent: {
-      flexGrow: 1,
+    content: {
+      flex: 1,
       justifyContent: "center",
-      paddingHorizontal: theme.spacing.xl,
-      paddingVertical: theme.spacing.xl,
       backgroundColor: theme.colors.background,
     },
     card: { gap: theme.spacing.lg },

--- a/components/ScreenWrapper.tsx
+++ b/components/ScreenWrapper.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import {
+  KeyboardAvoidingView,
+  TouchableWithoutFeedback,
+  Keyboard,
+  Platform,
+  ScrollView,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+export function ScreenWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <SafeAreaView style={{ flex: 1 }}>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={Platform.OS === "ios" ? 80 : 0}
+      >
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+          <ScrollView
+            contentContainerStyle={{
+              flexGrow: 1,
+              justifyContent: "center",
+              padding: 24,
+            }}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          >
+            <View style={{ flex: 1 }}>{children}</View>
+          </ScrollView>
+        </TouchableWithoutFeedback>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable ScreenWrapper layout with safe area and keyboard handling
- refactor the login and signup screens to use the new wrapper instead of nested keyboard-aware views
- simplify screen styling to rely on the shared wrapper while maintaining existing visuals

## Testing
- npm run typecheck *(fails: pre-existing issues in app/(auth)/_layout.tsx, app/(tabs)/estimates/[id].tsx, theme/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d25bfcfc83239f75dfcd4059ac3d