### PR TITLE
Refactor forgot password screen keyboard handling

### DIFF
--- a/app/(auth)/forgot-password.tsx
+++ b/app/(auth)/forgot-password.tsx
@@ -1,21 +1,12 @@
 import { Link } from "expo-router";
 import { useMemo, useState } from "react";
-import {
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  StyleSheet,
-  TouchableWithoutFeedback,
-  Keyboard,
-  View,
-} from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { Alert, StyleSheet, View } from "react-native";
 import { supabase } from "../../lib/supabase";
 import { BrandLogo } from "../../components/BrandLogo";
 import { Body, Button, Card, Input, Subtitle, Title } from "../../components/ui";
 import { Theme } from "../../theme";
 import { useThemeContext } from "../../theme/ThemeProvider";
+import { ScreenWrapper } from "../../components/ScreenWrapper";
 
 const RESET_REDIRECT = process.env.EXPO_PUBLIC_SUPABASE_RESET_REDIRECT;
 
@@ -50,72 +41,51 @@ export default function ForgotPasswordScreen() {
   };
 
   return (
-    <SafeAreaView style={styles.safeArea}>
-      <KeyboardAvoidingView
-        style={styles.keyboardAvoider}
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
-        keyboardVerticalOffset={Platform.OS === "ios" ? 80 : 0}
-      >
-        <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-          <ScrollView
-            keyboardShouldPersistTaps="handled"
-            contentContainerStyle={styles.scrollContent}
-            showsVerticalScrollIndicator={false}
-          >
-            <Card style={styles.card}>
-              <View style={styles.logoContainer}>
-                <BrandLogo size={80} />
-              </View>
-              <Title style={styles.title}>Reset your password</Title>
-              <Subtitle style={styles.subtitle}>
-                Enter the email linked to your account and we'll send reset
-                instructions.
-              </Subtitle>
+    <ScreenWrapper>
+      <View style={styles.content}>
+        <Card style={styles.card}>
+          <View style={styles.logoContainer}>
+            <BrandLogo size={80} />
+          </View>
+          <Title style={styles.title}>Reset your password</Title>
+          <Subtitle style={styles.subtitle}>
+            Enter the email linked to your account and we'll send reset
+            instructions.
+          </Subtitle>
 
-              <Input
-                autoCapitalize="none"
-                autoComplete="email"
-                autoCorrect={false}
-                keyboardType="email-address"
-                placeholder="you@example.com"
-                label="Email"
-                value={email}
-                onChangeText={setEmail}
-              />
+          <Input
+            autoCapitalize="none"
+            autoComplete="email"
+            autoCorrect={false}
+            keyboardType="email-address"
+            placeholder="you@example.com"
+            label="Email"
+            value={email}
+            onChangeText={setEmail}
+          />
 
-              <Button
-                label="Send reset link"
-                onPress={handleReset}
-                loading={loading}
-              />
+          <Button
+            label="Send reset link"
+            onPress={handleReset}
+            loading={loading}
+          />
 
-              <View style={styles.linksRow}>
-                <Link href="/(auth)/login">
-                  <Body style={styles.link}>Back to sign in</Body>
-                </Link>
-              </View>
-            </Card>
-          </ScrollView>
-        </TouchableWithoutFeedback>
-      </KeyboardAvoidingView>
-    </SafeAreaView>
+          <View style={styles.linksRow}>
+            <Link href="/(auth)/login">
+              <Body style={styles.link}>Back to sign in</Body>
+            </Link>
+          </View>
+        </Card>
+      </View>
+    </ScreenWrapper>
   );
 }
 
 function createStyles(theme: Theme) {
   return StyleSheet.create({
-    safeArea: {
+    content: {
       flex: 1,
-      backgroundColor: theme.colors.background,
-    },
-    keyboardAvoider: {
-      flex: 1,
-    },
-    scrollContent: {
-      flexGrow: 1,
       justifyContent: "center",
-      paddingHorizontal: theme.spacing.xl,
-      paddingVertical: theme.spacing.xl,
       backgroundColor: theme.colors.background,
     },
     card: {


### PR DESCRIPTION
## Summary
- replace the forgot password layout's keyboard avoiding stack with the shared ScreenWrapper
- keep the existing card layout while letting ScreenWrapper manage the safe area and keyboard behavior

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3d4ab578c8323a0281192d15c2474